### PR TITLE
Added regclass_<class> css class & hint: + (class) to show_regulariza…

### DIFF
--- a/static/CE_core/js/regularise.js
+++ b/static/CE_core/js/regularise.js
@@ -143,6 +143,7 @@ RG = (function() {
                       'scope': data[i].text[j][witness].decision_details[l].scope,
                       't': data[i].text[j][witness].decision_details[l].t.replace(/</g, '&lt;').replace(/>/g, '&gt;'),
                       'n': data[i].text[j][witness].decision_details[l].n.replace(/</g, '&lt;').replace(/>/g, '&gt;'),
+                      'class': data[i].text[j][witness].decision_details[l].class.replace(/[^a-zA-Z]'/g, '_'),
                       'witnesses': [witness]
                     };
                   }
@@ -162,6 +163,7 @@ RG = (function() {
                 if (_hasDeletionScheduled(key)) {
                   reg_class += 'deleted ';
                 }
+		reg_class += 'regclass_'+id_dict[key].class + ' ';
                 highlighted = '';
                 if (id_dict[key].witnesses.length > 1) {
                   id_dict[key].witnesses = CL.sortWitnesses(id_dict[key].witnesses);
@@ -189,7 +191,7 @@ RG = (function() {
                 } else {
                   cells_dict[id_dict[key].witnesses[0]] = [rule_cells.join(' ')];
                 }
-                events[subrow_id] = id_dict[key].scope + ': ' + _getRegWitsAsString(id_dict[key].witnesses);
+                events[subrow_id] = id_dict[key].scope + ': ' + _getRegWitsAsString(id_dict[key].witnesses) + ' (' + id_dict[key].class + ')';
               }
             }
             keys_to_sort = CL.sortWitnesses(keys_to_sort);


### PR DESCRIPTION
…tion row display the class of the rule and for custom styling to quickly differentiate.

So, users here have asked for a visual indication of why things were regularized.  This small patch simply adds a CSS class to the regularization row in the table, which allows clients to style their rule classes if they choose.  For those of us who don't see colors well, I have also included the rule class text in the event hover hint.