### PR TITLE
A fix for suffixes key when approving and getting apparatus

### DIFF
--- a/static/CE_core/js/collation.js
+++ b/static/CE_core/js/collation.js
@@ -1569,14 +1569,14 @@ CL = (function() {
   saveCollation = function(status, successCallback) {
     var collation, confirmed, confirmMessage, successMessage, approvalSettings;
     spinner.showLoadingOverlay();
+    collation = {
+        'structure': JSON.parse(JSON.stringify(CL.data)),
+        'status': status,
+        'context': CL.context,
+    };
     CL.services.getUserInfo(function(user) {
       if (user) {
-        collation = {
-          'structure': CL.data,
-          'status': status,
-          'context': CL.context,
-          'user': user.id
-        };
+        collation.user = user.id;
         if (status === 'regularised' && CL.witnessAddingMode === true) {
           collation.data_settings = CL.savedDataSettings;
           collation.algorithm_settings = CL.savedAlgorithmSettings;
@@ -1612,6 +1612,8 @@ CL = (function() {
         CL.services.saveCollation(CL.context, collation, confirmMessage, approvalSettings[0],
                                   approvalSettings[1], function(savedSuccessful) {
           document.getElementById('message_panel').innerHTML = savedSuccessful ? successMessage : '';
+          // I don't know why this is needed - somewhere in the code show/hide subreadings must be called after suffixes have been added
+          CL.data = collation.structure;
           if (savedSuccessful) { //only run success callback if successful!
             CL.isDirty = false;
             if (typeof successCallback !== 'undefined') {

--- a/static/CE_core/js/collation.js
+++ b/static/CE_core/js/collation.js
@@ -79,7 +79,7 @@ CL = (function() {
       _combinedGapInNextUnit, _getNewGapRdgDetails, _addExtraGapReadings, _extraGapIsWithinAnOverlap,
       _getInclusiveOverlapReadings, _getExtraGapLocation, _createExtraGaps, _addLacReading,
       _addNavEvent, _findLatestStageVerse, _loadLatestStageVerse, _removeOverlappedReadings,
-      _applySettings, _getApprovalSettings, _compareReadings,
+      _getApprovalSettings, _compareReadings,
       _disableEventPropagation, _showCollationSettings, _checkWitnesses, _getScrollPosition,
       _getMousePosition, _displayWitnessesHover, _getWitnessesForReading,
       _findStandoffWitness, _getPreStageChecks, _makeRegDecisionsStandoff,
@@ -1569,14 +1569,14 @@ CL = (function() {
   saveCollation = function(status, successCallback) {
     var collation, confirmed, confirmMessage, successMessage, approvalSettings;
     spinner.showLoadingOverlay();
-    collation = {
-        'structure': JSON.parse(JSON.stringify(CL.data)),
-        'status': status,
-        'context': CL.context,
-    };
     CL.services.getUserInfo(function(user) {
       if (user) {
-        collation.user = user.id;
+        collation = {
+          'structure': CL.data,
+          'status': status,
+          'context': CL.context,
+          'user': user.id
+        };
         if (status === 'regularised' && CL.witnessAddingMode === true) {
           collation.data_settings = CL.savedDataSettings;
           collation.algorithm_settings = CL.savedAlgorithmSettings;
@@ -1927,7 +1927,7 @@ CL = (function() {
   };
 
   findReadingByText = function(unit, text) {
-    var tokenList
+    var tokenList;
     for (let i = 0; i < unit.readings.length; i += 1) {
       if (unit.readings[i].hasOwnProperty('text_string') && unit.readings[i].text_string === text) {
         return unit.readings[i];
@@ -1992,7 +1992,7 @@ CL = (function() {
     return structuredTokens;
   };
 
-  makeStandoffReading = function(type, readingDetails, parentId, outerCallback) {
+  makeStandoffReading = function(type, readingDetails, parentId, outerCallback, skipSettings) {
     var apparatus, unit, parent, reading, fosilisedReading, tValuesForSettings, options, displaySettings,
       resultCallback, data;
     data = {};
@@ -2007,6 +2007,12 @@ CL = (function() {
     }
     fosilisedReading = JSON.parse(JSON.stringify(reading));
     tValuesForSettings = _extractAllTValuesForRGAppliedRules(reading, unit, apparatus);
+    // settings can only be skipped if there are no tokens to deal with (it is only relevant for combine lac/om readings)
+    if (tValuesForSettings.length === 0 && skipSettings === true) {
+        skipSettings = true;
+    } else {
+        skipSettings = false;
+    }
     options = {};
     displaySettings = {};
     for (let setting in CL.displaySettings) {
@@ -2019,21 +2025,30 @@ CL = (function() {
     options.display_settings = displaySettings;
     options.display_settings_config = CL.displaySettingsDetails;
 
-    resultCallback = function(data) {
-      var baseReadingsWithSettingsApplied;
-      baseReadingsWithSettingsApplied = {};
-      for (let i = 0; i < data.tokens.length; i += 1) {
-        baseReadingsWithSettingsApplied[data.tokens[i].t] = data.tokens[i]['interface'];
-      }
-      _makeStandoffReading2(reading, fosilisedReading, parent, baseReadingsWithSettingsApplied,
-                            type, unit, apparatus, readingDetails);
-      if (outerCallback !== undefined) {
-        outerCallback();
-      }
-    };
-    data.tokens = tValuesForSettings;
-    data.options = options;
-    CL.services.applySettings(data, resultCallback);
+    if (skipSettings === false) {
+        resultCallback = function(data) {
+          var baseReadingsWithSettingsApplied;
+          baseReadingsWithSettingsApplied = {};
+          for (let i = 0; i < data.tokens.length; i += 1) {
+            baseReadingsWithSettingsApplied[data.tokens[i].t] = data.tokens[i]['interface'];
+          }
+          _makeStandoffReading2(reading, fosilisedReading, parent, baseReadingsWithSettingsApplied,
+                                type, unit, apparatus, readingDetails);
+          if (outerCallback !== undefined) {
+            outerCallback();
+          }
+        };
+        data.tokens = tValuesForSettings;
+        data.options = options;
+        CL.services.applySettings(data, resultCallback);
+    } else {
+        _makeStandoffReading2(reading, fosilisedReading, parent, {},
+                              type, unit, apparatus, readingDetails);
+        if (outerCallback !== undefined) {
+           outerCallback();
+        }
+    }
+
   };
 
   _makeStandoffReading2 = function(reading, fosilisedReading, parent, baseReadingsWithSettingsApplied,
@@ -5791,7 +5806,6 @@ CL = (function() {
       _findLatestStageVerse: _findLatestStageVerse,
       _loadLatestStageVerse: _loadLatestStageVerse,
       _removeOverlappedReadings: _removeOverlappedReadings,
-      _applySettings: _applySettings,
       _getApprovalSettings: _getApprovalSettings,
       _compareReadings: _compareReadings,
       _disableEventPropagation: _disableEventPropagation,

--- a/static/CE_core/js/order_readings.js
+++ b/static/CE_core/js/order_readings.js
@@ -252,8 +252,11 @@ OR = (function() {
     if (CL.project.hasOwnProperty('showCollapseAllUnitsButton') && CL.project.showCollapseAllUnitsButton === true) {
       footerHtml.push('<button class="pure-button left_foot" id="expand_collapse_button">collapse all</button>');
     }
-    footerHtml.push('<button class="pure-button left_foot" id="show_hide_subreadings_button">' +
-                    showHideSubreadingsButtonText + '</button>');
+    // This button breaks the export in a very specific circumstance where a main reading has been created to
+    // allow a regularisation. It should not be available until a fix for show/hide subreadings once sigla suffixes
+    // has been extracted has been released
+    // footerHtml.push('<button class="pure-button left_foot" id="show_hide_subreadings_button">' +
+    //                 showHideSubreadingsButtonText + '</button>');
     footerHtml.push('<span id="extra_buttons"></span>');
     footerHtml.push('<span id="stage_links"></span>');
     if (CL.project.showGetApparatusButton === true) {
@@ -707,7 +710,7 @@ OR = (function() {
         // TODO: fosilise the reading suffixes and main reading label suffixes here
         // then make output dependent on these not being present
         _getMainReadingSpecialClasses();
-
+        // The following comment is no longer true as we do have that button in the approved screen!
         // at this point the saved approved version always and only ever has the correct subreadings shown we
         // don't have the option to show/hide subreadings in the interface so we can be sure they are always correct
         CL.saveCollation('approved', function() {
@@ -896,7 +899,7 @@ OR = (function() {
     labelForm.setAttribute('id', 'label_form');
     labelForm.setAttribute('class', 'label_form');
     html = [];
-    html.push('<div class="dialogue_form_header drag-zone">Edit Label</div>')
+    html.push('<div class="dialogue_form_header drag-zone">Edit Label</div>');
     html.push('<form id="label_change_form">');
     html.push('<label for="new_label">new label:<br/><input type="text" id="new_label"/></label><br/><br/>');
     html.push('<input class="pure-button dialogue-form-button" id="close_label_button" type="button" value="Cancel"/>');

--- a/static/CE_core/js/order_readings.js
+++ b/static/CE_core/js/order_readings.js
@@ -252,11 +252,8 @@ OR = (function() {
     if (CL.project.hasOwnProperty('showCollapseAllUnitsButton') && CL.project.showCollapseAllUnitsButton === true) {
       footerHtml.push('<button class="pure-button left_foot" id="expand_collapse_button">collapse all</button>');
     }
-    // This button breaks the export in a very specific circumstance where a main reading has been created to
-    // allow a regularisation. It should not be available until a fix for show/hide subreadings once sigla suffixes
-    // has been extracted has been released
-    // footerHtml.push('<button class="pure-button left_foot" id="show_hide_subreadings_button">' +
-    //                 showHideSubreadingsButtonText + '</button>');
+    footerHtml.push('<button class="pure-button left_foot" id="show_hide_subreadings_button">' +
+                    showHideSubreadingsButtonText + '</button>');
     footerHtml.push('<span id="extra_buttons"></span>');
     footerHtml.push('<span id="stage_links"></span>');
     if (CL.project.showGetApparatusButton === true) {
@@ -1788,10 +1785,12 @@ OR = (function() {
                 // this pass through. Somehow this still works!
                 if (reading) {
                   if (matchedReadings[unit._id][j].hasOwnProperty('subreadings')) {
-                    CL.makeStandoffReading('none', {'app_id': key,
-                                                    'unit_id': unit._id,
-                                                    'unit_pos': i,
-                                                    'reading_id': matchedReadings[unit._id][j].reading_id}, parentId);
+                    CL.makeStandoffReading('none',
+                                           {'app_id': key,
+                                            'unit_id': unit._id,
+                                            'unit_pos': i,
+                                            'reading_id': matchedReadings[unit._id][j].reading_id},
+                                            parentId, undefined, true);
                   } else {
                     CL.doMakeStandoffReading('none', key, unit, reading, newParent);
                   }

--- a/static/CE_core/js/order_readings.js
+++ b/static/CE_core/js/order_readings.js
@@ -1458,7 +1458,7 @@ OR = (function() {
         spinner.removeLoadingOverlay();
       });
     } else {
-      var url, settings, data;
+      var url, settings, callback;
       settings = JSON.parse(CL.getExporterSettings());
       if (!settings.hasOwnProperty('options')) {
         settings.options = {};
@@ -1466,23 +1466,40 @@ OR = (function() {
       settings.options.rule_classes = CL.ruleClasses;
       spinner.showLoadingOverlay();
       url = CL.services.apparatusServiceUrl;
-      data = {settings: JSON.stringify(settings),
-              data: JSON.stringify([{'context': CL.context, 'structure': CL.data}])
-              };
-      $.post(url, data).then(function (response) {
-          var blob, filename, downloadUrl, hiddenLink;
-          blob = new Blob([response], {'type': 'text/txt'});
-          filename = CL.context + '_apparatus.txt';
-          downloadUrl = window.URL.createObjectURL(blob);
-          hiddenLink = document.createElement('a');
-          hiddenLink.style.display = 'none';
-          hiddenLink.href = downloadUrl;
-          hiddenLink.download = filename;
-          document.body.appendChild(hiddenLink);
-          hiddenLink.click();
-          window.URL.revokeObjectURL(downloadUrl);
-          spinner.removeLoadingOverlay();
-      });
+      callback = function(collations) {
+          var collationId, innerCallback;
+          for (let i=0; i<collations.length; i+=1) {
+              if (collations[i].status === 'approved') {
+                  collationId = collations[i].id;
+              }
+          }
+          innerCallback = function (collation) {
+              var data;
+              data = {settings: JSON.stringify(settings),
+                      data: JSON.stringify([{'context': CL.context, 'structure': collation.structure}])
+                      };
+              $.post(url, data).then(function (response) {
+                  var blob, filename, downloadUrl, hiddenLink;
+                  blob = new Blob([response], {'type': 'text/txt'});
+                  filename = CL.context + '_apparatus.txt';
+                  downloadUrl = window.URL.createObjectURL(blob);
+                  hiddenLink = document.createElement('a');
+                  hiddenLink.style.display = 'none';
+                  hiddenLink.href = downloadUrl;
+                  hiddenLink.download = filename;
+                  document.body.appendChild(hiddenLink);
+                  hiddenLink.click();
+                  window.URL.revokeObjectURL(downloadUrl);
+                  spinner.removeLoadingOverlay();
+              }).fail(function (response) {
+                  alert('This unit cannot be exported 2. First try reapproving the unit. If the problem persists please ' +
+                        'recollate the unit from the collation home page.');
+                  spinner.removeLoadingOverlay();
+              });
+          };
+          loadSavedCollation(collationId, innerCallback);
+      };
+      getSavedCollations(CL.context, undefined, callback);
     }
   };
 


### PR DESCRIPTION
This solves a problem found by MUYA where problems with introducing the ApplySettings service was causing problems when combining lac/om readings at approval stage because of the asynchronous call. In these cases the settings are never needed because there will never be any tokens in lac or om readings so a version of makeStandoffReading which does not use the settings has been added. This stops the show/hide subreadings call in the settings applier callback from removing the suffixes key after it is added in the approve process.

In a similar way the show/hide non-edition subreadings button also removes the suffixes key and that breaks the getApparatus function. It is okay for the interface because the approved version can never be saved so the value of CL.data is irrelevant for anything other than display purposes. To fix the getApparatus function the data for the unit is now always retrieved from the database rather than from CL.data.