### PR TITLE
sigla suffix in hover over

### DIFF
--- a/README.md
+++ b/README.md
@@ -878,6 +878,21 @@ There are probably very few, if any, good reasons to use this. It is present to 
 This function is required if ```prepareDisplayString()``` is used. It must exactly reverse the changes made to the string by that function. It is used when making regularisation rules to ensure the stored strings are what is expected and can be transformed by ```prepareNormalisedString()``` correctly in the display.
 
 
+Additional Optional Project Settings
+---
+
+Many of the options available in the services file can also be added to individual project configurations to override the settings in the services file. If this is the case it will be indicated in the documentation for the services file. This section details optional settings not available at the services level.
+
+
+- #### ```witnessDecorators```
+
+The data should be structured as a JSON object. It should have at least two top level keys with one optional key:
+
+- **label** *[string]* - The string/character used to decorate the witness siglum.
+- **superscript** *[boolean]* optional - If set to true the deocrator will be superscripted when displayed.
+- **witnesses** *[array]* - A list of witness which should be decoarated (this should always be a subset of the witnesses specified for the project).
+
+
 Python/Server Services
 ---
 
@@ -1393,5 +1408,6 @@ Changelog 2.x release
 Catena Dev branch changes
 ---
 
-* Optional services and project setting added *storeMultipleSupportLabelsAsParents* which changes the behaviour of the label editing in order readings and stores support for multiple readings using the reading data itself so that it can be preserved and updated when readings are reordered. If this setting is used and set to true it will not have any impact on existing data but will offer the new label storage option for existing data.
+* Optional services and project setting *storeMultipleSupportLabelsAsParents* added which changes the behaviour of the label editing in order readings and stores support for multiple readings using the reading data itself so that it can be preserved and updated when readings are reordered. If this setting is used and set to true it will not have any impact on existing data but will offer the new label storage option for existing data.
 
+* Optional project setting *witnessDecorators* added. This is not available at the services level as the data will be specific to each project. The structure is explained above in the optional project settings section. If data is provided then all hands from that witness will have the label appended after them in the hover overs of the collation editor. This was introduced to provide an easy way to see a group of manuscripts when the grouping was not otherwise made obvious in the sigla. The specific example from the New Testament is the use of a superscript K to make commentary manuscripts more easily identifiable.

--- a/static/CE_core/js/collation.js
+++ b/static/CE_core/js/collation.js
@@ -64,7 +64,7 @@ CL = (function() {
       loadIndexPage, addIndexHandlers, getHandsAndSigla, createNewReading, getReadingWitnesses,
       calculatePosition, removeWitness, checkWitnessesAgainstProject, setUpRemoveWitnessesForm,
       removeWitnesses, getRemoveWitnessDataFromForm, returnToSummaryTable, prepareAdditionalCollation,
-      removeSpecialWitnesses, runFunction, setOverlappedOptions, setRuleClasses;
+      removeSpecialWitnesses, runFunction, setOverlappedOptions, setRuleClasses, expandWitnessDecorators;
 
   //private function declarations
   let _initialiseEditor, _initialiseProject, _setProjectConfig, _setDisplaySettings,
@@ -179,6 +179,23 @@ CL = (function() {
     }
     unit._id = MD5(text.join(''));
     return unit._id;
+  };
+
+  expandWitnessDecorators = function () {
+    for (let i = 0; i < CL.project.witnessDecorators.length; i += 1) {
+      let hands = [];
+      for (let key in CL.data.hand_id_map) {
+        if (CL.project.witnessDecorators[i].witnesses.indexOf(CL.data.hand_id_map[key]) !== -1) {
+          hands.push(key);
+        }
+      }
+      if (CL.project.witnessDecorators[i].superscript == true) {
+        CL.project.witnessDecorators[i].display = '<sup>' + CL.project.witnessDecorators[i].label + '</sup>';
+      } else {
+        CL.project.witnessDecorators[i].display = CL.project.witnessDecorators[i].label;
+      }
+      CL.project.witnessDecorators[i].hands = hands;
+    }
   };
 
   /** */
@@ -2922,7 +2939,17 @@ CL = (function() {
           }
         }
       }
-      witnesses.push(witness + suffix);
+      if (CL.project.witnessDecorators !== null) {
+        let decorator = [];
+        for (let i = 0; i < CL.project.witnessDecorators.length; i += 1) {
+          if (CL.project.witnessDecorators[i].hands.indexOf(witness) !== -1) {
+            decorator.push(CL.project.witnessDecorators[i].display);
+          }
+        }
+        witnesses.push(witness + decorator.join('') + suffix);
+      } else {
+        witnesses.push(witness + suffix);
+      } 
     }
     witnesses = sortWitnesses(witnesses);
     return witnesses;
@@ -3009,6 +3036,11 @@ CL = (function() {
     }
     if (project.hasOwnProperty('extractWordsForHeader') && typeof project.extractWordsForHeader === 'string') {
       CL.project.extractWordsForHeader = _getFunctionFromString(project.extractWordsForHeader);
+    }
+    if (project.hasOwnProperty('witnessDecorators')) {
+      CL.project.witnessDecorators = project.witnessDecorators;
+    } else {
+      CL.project.witnessDecorators = null;
     }
 
     if (project.hasOwnProperty('prepareDisplayString') && typeof project.prepareDisplayString === 'string') {
@@ -5760,6 +5792,7 @@ CL = (function() {
       removeSpecialWitnesses: removeSpecialWitnesses,
       findReadingPosById: findReadingPosById,
       runFunction: runFunction,
+      expandWitnessDecorators: expandWitnessDecorators,
 
       //deprecated function mapping for calls from older services
       set_service_provider: setServiceProvider,
@@ -5955,6 +5988,7 @@ CL = (function() {
       prepareAdditionalCollation: prepareAdditionalCollation,
       removeSpecialWitnesses: removeSpecialWitnesses,
       runFunction: runFunction,
+      expandWitnessDecorators: expandWitnessDecorators,
 
       //deprecated function mapping for calls from older services
       set_service_provider: setServiceProvider,

--- a/static/CE_core/js/order_readings.js
+++ b/static/CE_core/js/order_readings.js
@@ -51,6 +51,9 @@ OR = (function() {
     } else {
       container = options.container;
     }
+    if (CL.project.witnessDecorators !== null) {
+      CL.expandWitnessDecorators();
+    }
     //sort out options and get layout
     if (!options.hasOwnProperty('highlighted_wit') && CL.highlighted !== 'none') {
       options.highlighted_wit = CL.highlighted;
@@ -209,6 +212,9 @@ OR = (function() {
       container = document.getElementsByTagName('body')[0];
     } else {
       container = options.container;
+    }
+    if (CL.project.witnessDecorators !== null) {
+      CL.expandWitnessDecorators();
     }
     //sort out options and get layout
     if (!options.hasOwnProperty('highlighted_wit') && CL.highlighted !== 'none') {

--- a/static/CE_core/js/regularise.js
+++ b/static/CE_core/js/regularise.js
@@ -325,6 +325,9 @@ RG = (function() {
     if (!options.hasOwnProperty('highlighted_wit') && CL.highlighted !== 'none') {
       options.highlighted_wit = CL.highlighted;
     }
+    if (CL.project.witnessDecorators !== null) {
+      CL.expandWitnessDecorators();
+    }
     if (CL.witnessAddingMode === true) {
 			// this sets this a default so that when all is highlighted this will work - any data specified
       // in options will override it

--- a/static/CE_core/js/set_variants.js
+++ b/static/CE_core/js/set_variants.js
@@ -83,6 +83,9 @@ SV = (function() {
     } else {
       container = document.getElementsByTagName('body')[0];
     }
+    if (CL.project.witnessDecorators !== null) {
+      CL.expandWitnessDecorators();
+    }
     if (CL.witnessRemovingMode !== true) {
       // attach right click menus
       SimpleContextMenu.setup({


### PR DESCRIPTION
Settings and documentation to allow decorators to sigla in hover overs in the collation editor display. Introduced to allow Commentary manuscripts to be marked with a superscript K but could have other uses.