### PR TITLE
1cor dev inner unit collation for moved readings

### DIFF
--- a/static/CE_core/js/set_variants.js
+++ b/static/CE_core/js/set_variants.js
@@ -1585,7 +1585,7 @@ var SV = (function() {
                                                                               firstWordIndex);
                       }
                     }
-                  } 
+                  }
                 }
               }
               k += 1;
@@ -1743,7 +1743,7 @@ var SV = (function() {
   
     _decrementSubIndex: function(current, decrement) {
       let subIndex;
-      let mainIndex = parseInt(current.split('.')[0]);
+      const mainIndex = parseInt(current.split('.')[0]);
       subIndex = parseInt(current.split('.')[1]);
       subIndex = subIndex - decrement;
       return mainIndex + '.' + subIndex;

--- a/static/CE_core/js/set_variants.js
+++ b/static/CE_core/js/set_variants.js
@@ -1714,7 +1714,7 @@ var SV = (function() {
         if (previousIndex === -1) {
           previousIndex = mainIndexes.indexOf(missingIndexes[i] - 2);
         }
-        nextIndex = -1
+        nextIndex = -1;
         nextIndex = mainIndexes.indexOf(missingIndexes[i] + 1);
         if (nextIndex === -1) {
           nextIndex = mainIndexes.indexOf(missingIndexes[i] + 2);

--- a/static/CE_core/js/set_variants.js
+++ b/static/CE_core/js/set_variants.js
@@ -1567,7 +1567,6 @@ var SV = (function() {
             while (!found && k < unit.readings.length) {
               if (unit.readings[k].witnesses.indexOf(witnesses[j]) !== -1) {
                 found = true;
-                // check to see if the whole reading needs reindexing and if so use the matching function
                 // check to see if at least half of the reading needs reindexing and if so use the matching function
                 const undefinedIndexes = unit.readings[k].text.map(x => x.index).filter(x => typeof x === 'undefined');
                 if (unit.readings[k].text.length > 0 && undefinedIndexes.length > unit.readings[k].text.length / 2) {

--- a/static/CE_core/js/set_variants.js
+++ b/static/CE_core/js/set_variants.js
@@ -1617,7 +1617,7 @@ var SV = (function() {
       const distances = readingTexts.map(x => SV._levenstein(x, movedReadingText));
       let shortestDistance = distances.indexOf(Math.min(...distances));
       let closestReading = unit.readings[shortestDistance];
-      // if the reading we found is not yet indexed itself and options are still available then keep looking
+      // if the reading we found does not yet have index numbers for all of its words and other reading options are still available then keep looking
       while (
         distances.filter(x => x === Infinity).length < distances.length - 1 && 
         closestReading.text.map(x => x.index).filter(x => x === undefined).length === 0

--- a/static/CE_core/js/set_variants.js
+++ b/static/CE_core/js/set_variants.js
@@ -1648,6 +1648,7 @@ var SV = (function() {
             } else {
               // if we don't have a match then make something up based on the other positions in the moved reading
               if (i === 0) {
+                // 1000 here just makes sure it is always the last thing in the previous unit.
                 movedReading.text[i].index = (parseInt(closestReading.text[0].index) - 1) + '.' + '1000';
               } else {
                 movedReading.text[i].index = SV._incrementSubIndex(movedReading.text[i-1].index, 1);
@@ -1661,8 +1662,8 @@ var SV = (function() {
     _levenstein: function (s1, s2) {
       /* A JavaScript implementation of the levenstein distance algorithm - originally adapted from a tutorial online */
       if (s1 === '' || s2 === '') {
-        // returning a high number here because otherwise short readings will have lowest distance to empty string
-        return 1000;
+        // returning infinity here because otherwise short readings will have lowest distance to empty string
+        return Infinity;
       }
       const matrix = [];
       for (let i = 0; i <= s2.length; i += 1) {

--- a/static/CE_core/js/set_variants.js
+++ b/static/CE_core/js/set_variants.js
@@ -1614,7 +1614,13 @@ var SV = (function() {
         }
       }
       const distances = readingTexts.map(x => SV._levenstein(x, movedReadingText));
-      const closestReading = unit.readings[distances.indexOf(Math.min(...distances))];
+      let shortestDistance = distances.indexOf(Math.min(...distances));
+      let closestReading = unit.readings[shortestDistance];
+      while (closestReading.text[0].index === undefined) {
+        distances[shortestDistance] = Infinity;
+        shortestDistance = distances.indexOf(Math.min(...distances));
+        closestReading = unit.readings[shortestDistance];
+      }
       if (movedReading.text.length === closestReading.text.length) {
         // then just steal the indexes from the closest reading
         for (let i = 0; i < movedReading.text.length; i += 1) {

--- a/static/js_tests/test_set_variants/test_SV_checkAndFixRecalculatedIndexes.html
+++ b/static/js_tests/test_set_variants/test_SV_checkAndFixRecalculatedIndexes.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width">
+  <title>SV._checkAndFixRecalculatedIndexes tests</title>
+  <link rel="stylesheet" href="../../../../../node_modules/qunit/qunit/qunit.css">
+</head>
+<body>
+  	<script src="../../../../../common-static/js/jquery-3.7.1.min.js"></script>
+	<script src="../../../../../node_modules/sinon/pkg/sinon.js"></script>
+	<script src="../../../../../node_modules/qunit/qunit/qunit.js"></script>
+	<script src="../../CE_core/js/collation.js"></script>
+  	<script src="../../CE_core/js/set_variants.js"></script>
+	<script src="./test_SV_checkAndFixRecalculatedIndexes.js"></script>
+
+  	<div id="qunit"></div>
+ 	<div id="qunit-fixture">
+	</div>
+</body>
+</html>

--- a/static/js_tests/test_set_variants/test_SV_checkAndFixRecalculatedIndexes.js
+++ b/static/js_tests/test_set_variants/test_SV_checkAndFixRecalculatedIndexes.js
@@ -1,0 +1,196 @@
+/* global QUnit, sinon, SV */
+
+QUnit.module('SV _checkAndFixRecalculatedIndexes', function(hooks) {
+
+    hooks.afterEach(function () {
+        sinon.restore();
+    });
+
+    QUnit.test("test a no indexing missing", (assert) => {
+
+        const reading = {
+            'text': [
+                {'index': '2.1'},
+                {'index': '4.1'},
+                {'index': '6.1'},
+                {'index': '8.1'},
+                {'index': '10.1'},
+            ],
+        } 
+        SV._checkAndFixRecalculatedIndexes(reading, 2, 10);
+        assert.deepEqual(reading.text.map(x => x.index), ['2.1', '4.1', '6.1', '8.1', '10.1'])
+    });
+
+    QUnit.test("test a simple reindex with no length difference", (assert) => {
+
+        const reading = {
+            'text': [
+                {'index': '2.1'},
+                {'index': '2.2'},
+                {'index': '2.3'},
+                {'index': '2.4'},
+                {'index': '10.1'},
+            ],
+        } 
+        SV._checkAndFixRecalculatedIndexes(reading, 2, 10);
+        assert.deepEqual(reading.text.map(x => x.index), ['2.1', '4.1', '6.1', '8.1', '10.1'])
+    });
+
+    QUnit.test("test a simple reindex with shorter reading", (assert) => {
+
+        const reading = {
+            'text': [
+                {'index': '2.1'},
+                {'index': '2.2'},
+                {'index': '2.3'},
+                {'index': '10.1'},
+            ],
+        } 
+        SV._checkAndFixRecalculatedIndexes(reading, 2, 10);
+        assert.deepEqual(reading.text.map(x => x.index), ['2.1', '4.1', '6.1', '10.1'])
+    });
+
+    QUnit.test("test a simple reindex with longer reading", (assert) => {
+
+        const reading = {
+            'text': [
+                {'index': '2.1'},
+                {'index': '2.2'},
+                {'index': '2.3'},
+                {'index': '2.4'},
+                {'index': '2.5'},
+                {'index': '2.6'},
+                {'index': '10.1'},
+            ],
+        } 
+        SV._checkAndFixRecalculatedIndexes(reading, 2, 10);
+        assert.deepEqual(reading.text.map(x => x.index), ['2.1', '4.1', '6.1', '8.1', '8.2', '8.3','10.1'])
+    });
+
+    QUnit.test("test a simple reindex with longer reading more at end too", (assert) => {
+
+        const reading = {
+            'text': [
+                {'index': '2.1'},
+                {'index': '2.2'},
+                {'index': '2.3'},
+                {'index': '2.4'},
+                {'index': '2.5'},
+                {'index': '2.6'},
+                {'index': '10.1'},
+                {'index': '10.2'},
+                {'index': '10.3'},
+            ],
+        } 
+        SV._checkAndFixRecalculatedIndexes(reading, 2, 10);
+        assert.deepEqual(reading.text.map(x => x.index), ['2.1', '4.1', '6.1', '8.1', '8.2', '8.3','10.1', '10.2', '10.3'])
+    });
+
+    QUnit.test("test a reindex with a first position change", (assert) => {
+
+        const reading = {
+            'text': [
+                {'index': '1.1000'},
+                {'index': '4.1'},
+                {'index': '4.2'},
+                {'index': '10.1'},
+            ],
+        }
+        SV._checkAndFixRecalculatedIndexes(reading, 2, 10);
+        assert.deepEqual(reading.text.map(x => x.index), ['2.1', '4.1', '6.1', '10.1'])
+    });
+
+    QUnit.test("test a reindex with a first position change", (assert) => {
+
+        const reading = {
+            'text': [
+                {'index': '1.1000'},
+                {'index': '2.1'},
+                {'index': '4.1'},
+                {'index': '10.1'},
+            ],
+        }
+        SV._checkAndFixRecalculatedIndexes(reading, 2, 10);
+        assert.deepEqual(reading.text.map(x => x.index), ['1.1000', '2.1', '4.1', '10.1'])
+    });
+
+    QUnit.test("test a reindex with odd number", (assert) => {
+
+        const reading = {
+            'text': [
+                {'index': '2.1'},
+                {'index': '3.1'},
+                {'index': '4.1'},
+                {'index': '4.2'},
+                {'index': '10.1'},
+            ],
+        }
+        SV._checkAndFixRecalculatedIndexes(reading, 2, 10);
+        assert.deepEqual(reading.text.map(x => x.index), ['2.1', '3.1', '4.1', '6.1', '10.1'])
+    });
+
+    QUnit.test("test a reindex with odd number at end", (assert) => {
+
+        const reading = {
+            'text': [
+                {'index': '2.1'},
+                {'index': '3.1'},
+                {'index': '4.1'},
+                {'index': '4.2'},
+                {'index': '9.1'},
+            ],
+        }
+        SV._checkAndFixRecalculatedIndexes(reading, 2, 10);
+        assert.deepEqual(reading.text.map(x => x.index), ['2.1', '3.1', '4.1', '6.1', '9.1'])
+    });
+
+    QUnit.test("test a reindex with odd number after repeat (should not change)", (assert) => {
+
+        const reading = {
+            'text': [
+                {'index': '2.1'},
+                {'index': '2.2'},
+                {'index': '3.1'},
+                {'index': '4.1'},
+                {'index': '10.1'},
+            ],
+        }
+        SV._checkAndFixRecalculatedIndexes(reading, 2, 10);
+        assert.deepEqual(reading.text.map(x => x.index), ['2.1', '2.2', '3.1', '4.1', '10.1'])
+    });
+
+    QUnit.test("test a reindex with odd number after multiple repeats (should not change)", (assert) => {
+
+        const reading = {
+            'text': [
+                {'index': '2.1'},
+                {'index': '2.2'},
+                {'index': '2.3'},
+                {'index': '3.1'},
+                {'index': '10.1'},
+            ],
+        }
+        SV._checkAndFixRecalculatedIndexes(reading, 2, 10);
+        assert.deepEqual(reading.text.map(x => x.index), ['2.1', '2.2', '2.3', '3.1', '10.1'])
+    });
+
+    QUnit.test("test a reindex with odd number after multiple repeats which also needs changes", (assert) => {
+
+        const reading = {
+            'text': [
+                {'index': '2.1'},
+                {'index': '2.2'},
+                {'index': '2.3'},
+                {'index': '3.1'},
+                {'index': '4.1'},
+                {'index': '4.2'},
+                {'index': '4.3'},
+                {'index': '4.4'},
+                {'index': '10.1'},
+            ],
+        }
+        SV._checkAndFixRecalculatedIndexes(reading, 2, 10);
+        assert.deepEqual(reading.text.map(x => x.index), ['2.1', '2.2', '2.3', '3.1', '4.1', '6.1', '8.1','8.2', '10.1'])
+    });
+
+});

--- a/static/js_tests/test_set_variants/test_SV_getSharedWordsList.html
+++ b/static/js_tests/test_set_variants/test_SV_getSharedWordsList.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width">
+  <title>SV._getSharedWordsList tests</title>
+  <link rel="stylesheet" href="../../../../../node_modules/qunit/qunit/qunit.css">
+</head>
+<body>
+  	<script src="../../../../../common-static/js/jquery-3.7.1.min.js"></script>
+	<script src="../../../../../node_modules/sinon/pkg/sinon.js"></script>
+	<script src="../../../../../node_modules/qunit/qunit/qunit.js"></script>
+	<script src="../../CE_core/js/collation.js"></script>
+  	<script src="../../CE_core/js/set_variants.js"></script>
+	<script src="./test_SV_getSharedWordsList.js"></script>
+
+  	<div id="qunit"></div>
+ 	<div id="qunit-fixture">
+	</div>
+</body>
+</html>

--- a/static/js_tests/test_set_variants/test_SV_getSharedWordsList.js
+++ b/static/js_tests/test_set_variants/test_SV_getSharedWordsList.js
@@ -1,0 +1,52 @@
+/* global QUnit, sinon, SV */
+
+QUnit.module('SV _reindexMovedReadingByMatching', function(hooks) {
+
+    hooks.afterEach(function () {
+        sinon.restore();
+    });
+
+    QUnit.test("test shared words in order no duplicates", (assert) => {
+        const closestReadingWords = ['one', 'two', 'three', 'four'];
+        const movedReadingWords = ['one', 'two', 'three', 'four'];
+        const result = SV._getSharedWordsList(closestReadingWords, movedReadingWords);
+        assert.deepEqual(result, ['one', 'two', 'three', 'four']);
+    });
+
+    QUnit.test("test shared words out of order no duplicates", (assert) => {
+        const closestReadingWords = ['one', 'two', 'three', 'four'];
+        const movedReadingWords = ['two', 'three', 'one', 'four'];
+        const result = SV._getSharedWordsList(closestReadingWords, movedReadingWords);
+        assert.deepEqual(result, ['two', 'three', 'four']);
+    });
+
+    QUnit.test("test shared words more out of order no duplicates 1", (assert) => {
+        const closestReadingWords = ['one', 'two', 'three', 'four'];
+        const movedReadingWords = ['two', 'one', 'four', 'three'];
+        const result = SV._getSharedWordsList(closestReadingWords, movedReadingWords);
+        assert.deepEqual(result, ['two', 'four']);
+    });
+
+    QUnit.test("test shared words more out of order with duplicates 2", (assert) => {
+        const closestReadingWords = ['one', 'two', 'two', 'three', 'four'];
+        const movedReadingWords = ['one', 'two', 'four', 'one', 'four', 'three'];
+        const result = SV._getSharedWordsList(closestReadingWords, movedReadingWords);
+        assert.deepEqual(result, ['one', 'two', 'four']);
+    });
+
+    QUnit.test("test shared words more out of order with duplicates 3", (assert) => {
+        const closestReadingWords = ['one', 'four', 'two', 'two', 'three', 'four'];
+        const movedReadingWords = ['one', 'two', 'four', 'one', 'four', 'three'];
+        const result = SV._getSharedWordsList(closestReadingWords, movedReadingWords);
+        assert.deepEqual(result, ['one', 'two', 'four']);
+    });
+
+    QUnit.test("test shared words more out of order with duplicates 3", (assert) => {
+        const closestReadingWords = ['one', 'four', 'two', 'two', 'three'];
+        const movedReadingWords = ['one', 'two', 'four', 'one', 'four', 'three'];
+        const result = SV._getSharedWordsList(closestReadingWords, movedReadingWords);
+        assert.deepEqual(result, ['one', 'two', 'three']);
+    });
+
+
+});

--- a/static/js_tests/test_set_variants/test_SV_getSharedWordsList.js
+++ b/static/js_tests/test_set_variants/test_SV_getSharedWordsList.js
@@ -1,6 +1,6 @@
 /* global QUnit, sinon, SV */
 
-QUnit.module('SV _reindexMovedReadingByMatching', function(hooks) {
+QUnit.module('SV _getSharedWordsList', function(hooks) {
 
     hooks.afterEach(function () {
         sinon.restore();

--- a/static/js_tests/test_set_variants/test_SV_reindexMovedReadingsByMatching.html
+++ b/static/js_tests/test_set_variants/test_SV_reindexMovedReadingsByMatching.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width">
+  <title>SV._reindexMovedReadingsByMatching tests</title>
+  <link rel="stylesheet" href="../../../../../node_modules/qunit/qunit/qunit.css">
+</head>
+<body>
+  	<script src="../../../../../common-static/js/jquery-3.7.1.min.js"></script>
+	<script src="../../../../../node_modules/sinon/pkg/sinon.js"></script>
+	<script src="../../../../../node_modules/qunit/qunit/qunit.js"></script>
+	<script src="../../CE_core/js/collation.js"></script>
+  	<script src="../../CE_core/js/set_variants.js"></script>
+	<script src="./test_SV_reindexMovedReadingsByMatching.js"></script>
+
+  	<div id="qunit"></div>
+ 	<div id="qunit-fixture">
+	</div>
+</body>
+</html>

--- a/static/js_tests/test_set_variants/test_SV_reindexMovedReadingsByMatching.js
+++ b/static/js_tests/test_set_variants/test_SV_reindexMovedReadingsByMatching.js
@@ -1,0 +1,255 @@
+/* global QUnit, sinon, CL, SV */
+
+QUnit.module('SV _reindexMovedReadingByMatching', function(hooks) {
+
+    hooks.afterEach(function () {
+        sinon.restore();
+    });
+
+    QUnit.test("test no words have exact matches", (assert) => {
+        const readings = [
+            {'witnesses': ['01'], 'text': [
+                {'interface': 'one', 'index': '2.1'},
+                {'interface': 'two', 'index': '4.1'},
+            ]},
+            {'witnesses': ['P45'], 'text': [
+                {'interface': 'once'},
+                {'interface': 'twice'},
+            ]}
+        ];
+        CL.data = {
+            'apparatus': [
+                {
+                    'start': 2,
+                    'end': 4,
+                    'readings': readings}
+            ]
+        };
+        SV._reindexMovedReadingByMatching(2, 'P45');
+        // TODO: this ideally should be ['2.1', '4.1']
+        assert.deepEqual(readings[1].text.map(x => x.index), ['2.1', '4.1'])
+    });
+
+    QUnit.test("test no readings have indexes yet (should probably never happen)", (assert) => {
+        const readings = [
+            {'witnesses': ['01'], 'text': [
+                {'interface': 'one'},
+                {'interface': 'two'},
+            ]},
+            {'witnesses': ['P45'], 'text': [
+                {'interface': 'once'},
+                {'interface': 'twice'},
+            ]}
+        ];
+        CL.data = {
+            'apparatus': [
+                {
+                    'start': 2,
+                    'end': 4,
+                    'readings': readings}
+            ]
+        };
+        SV._reindexMovedReadingByMatching(2, 'P45');
+        // TODO: this ideally should be ['2.1', '4.1']
+        assert.deepEqual(readings[1].text.map(x => x.index), ['2.1', '4.1'])
+    });
+
+    QUnit.test("test first word has exact match", (assert) => {
+        const readings = [
+            {'witnesses': ['01'], 'text': [
+                {'interface': 'one', 'index': '2.1'},
+                {'interface': 'two', 'index': '4.1'},
+            ]},
+            {'witnesses': ['P45'], 'text': [
+                {'interface': 'one'},
+                {'interface': 'twice'},
+            ]}
+        ];
+        CL.data = {
+            'apparatus': [
+                {
+                    'start': 2,
+                    'end': 4,
+                    'readings': readings}
+            ]
+        };
+
+        SV._reindexMovedReadingByMatching(2, 'P45');
+        // TODO: this ideally should be ['2.1', '4.1']
+        assert.deepEqual(readings[1].text.map(x => x.index), ['2.1', '4.1'])
+    });
+
+    QUnit.test("test second word has exact match", (assert) => {
+        const readings = [
+            {'witnesses': ['01'], 'text': [
+                {'interface': 'one', 'index': '2.1'},
+                {'interface': 'two', 'index': '4.1'},
+            ]},
+            {'witnesses': ['P45'], 'text': [
+                {'interface': 'once'},
+                {'interface': 'two'},
+            ]}
+        ];
+        CL.data = {
+            'apparatus': [
+                {
+                    'start': 2,
+                    'end': 4,
+                    'readings': readings}
+            ]
+        };
+
+        SV._reindexMovedReadingByMatching(2, 'P45');
+        assert.deepEqual(readings[1].text.map(x => x.index), ['2.1', '4.1'])
+    });
+
+    QUnit.test("test different lengths no first word match", (assert) => {
+        const readings = [
+            {'witnesses': ['01'], 'text': [
+                {'interface': 'one', 'index': '2.1'},
+                {'interface': 'two', 'index': '4.1'},
+            ]},
+            {'witnesses': ['P45'], 'text': [
+                {'interface': 'zero'},
+                {'interface': 'one'},
+                {'interface': 'two'},
+            ]}
+        ];
+        CL.data = {
+            'apparatus': [
+                {
+                    'start': 2,
+                    'end': 4,
+                    'readings': readings}
+            ]
+        };
+        SV._reindexMovedReadingByMatching(2, 'P45');
+        assert.deepEqual(readings[1].text.map(x => x.index), ['1.1000', '2.1', '4.1'])
+    });
+
+    QUnit.test("test different lengths no middle word match", (assert) => {
+        const readings = [
+            {'witnesses': ['01'], 'text': [
+                {'interface': 'one', 'index': '2.1'},
+                {'interface': 'two', 'index': '4.1'},
+            ]},
+            {'witnesses': ['P45'], 'text': [
+                {'interface': 'one'},
+                {'interface': 'middle'},
+                {'interface': 'two'},
+            ]}
+        ];
+        CL.data = {
+            'apparatus': [
+                {
+                    'start': 2,
+                    'end': 4,
+                    'readings': readings}
+            ]
+        };
+        SV._reindexMovedReadingByMatching(2, 'P45');
+        assert.deepEqual(readings[1].text.map(x => x.index), ['2.1', '2.2', '4.1'])
+    });
+
+    QUnit.test("test different lengths no end word match", (assert) => {
+        const readings = [
+            {'witnesses': ['01'], 'text': [
+                {'interface': 'one', 'index': '2.1'},
+                {'interface': 'two', 'index': '4.1'},
+            ]},
+            {'witnesses': ['P45'], 'text': [
+                {'interface': 'one'},
+                {'interface': 'two'},
+                {'interface': 'three'},
+            ]}
+        ];
+        CL.data = {
+            'apparatus': [
+                {
+                    'start': 2,
+                    'end': 4,
+                    'readings': readings}
+            ]
+        };
+        SV._reindexMovedReadingByMatching(2, 'P45');
+        assert.deepEqual(readings[1].text.map(x => x.index), ['2.1', '4.1', '4.2'])
+    });
+
+    QUnit.test("test different lengths offset matches", (assert) => {
+        const readings = [
+            {'witnesses': ['01'], 'text': [
+                {'interface': 'one', 'index': '2.1'},
+                {'interface': 'two', 'index': '4.1'},
+                {'interface': 'three', 'index': '6.1'},
+            ]},
+            {'witnesses': ['P45'], 'text': [
+                {'interface': 'one'},
+                {'interface': 'half'},
+                {'interface': 'two'},
+            ]}
+        ];
+        CL.data = {
+            'apparatus': [
+                {
+                    'start': 2,
+                    'end': 6,
+                    'readings': readings}
+            ]
+        };
+        SV._reindexMovedReadingByMatching(2, 'P45');
+        assert.deepEqual(readings[1].text.map(x => x.index), ['2.1', '2.2', '4.1'])
+    });
+
+    QUnit.test("test different lengths repeated word in moved", (assert) => {
+        const readings = [
+            {'witnesses': ['01'], 'text': [
+                {'interface': 'one', 'index': '2.1'},
+                {'interface': 'two', 'index': '4.1'},
+                {'interface': 'three', 'index': '6.1'},
+            ]},
+            {'witnesses': ['P45'], 'text': [
+                {'interface': 'one'},
+                {'interface': 'one'},
+                {'interface': 'three'},
+            ]}
+        ];
+        CL.data = {
+            'apparatus': [
+                {
+                    'start': 2,
+                    'end': 6,
+                    'readings': readings}
+            ]
+        };
+        SV._reindexMovedReadingByMatching(2, 'P45');
+        // TODO: would ideally be 2.1, 4.1, 6.1
+        assert.deepEqual(readings[1].text.map(x => x.index), ['2.1', '4.1', '6.1'])
+    });
+
+    QUnit.test("test different lengths repeated word in closest match", (assert) => {
+        const readings = [
+            {'witnesses': ['01'], 'text': [
+                {'interface': 'one', 'index': '2.1'},
+                {'interface': 'one', 'index': '4.1'},
+                {'interface': 'three', 'index': '6.1'},
+            ]},
+            {'witnesses': ['P45'], 'text': [
+                {'interface': 'one'},
+                {'interface': 'two'},
+                {'interface': 'three'},
+            ]}
+        ];
+        CL.data = {
+            'apparatus': [
+                {
+                    'start': 2,
+                    'end': 6,
+                    'readings': readings}
+            ]
+        };
+        SV._reindexMovedReadingByMatching(2, 'P45');
+        // TODO: would ideally be 2.1, 4.1, 6.1
+        assert.deepEqual(readings[1].text.map(x => x.index), ['2.1', '4.1', '6.1'])
+    });
+
+});

--- a/static/js_tests/test_set_variants/test_SV_reindexMovedReadingsByMatching.js
+++ b/static/js_tests/test_set_variants/test_SV_reindexMovedReadingsByMatching.js
@@ -26,7 +26,6 @@ QUnit.module('SV _reindexMovedReadingByMatching', function(hooks) {
             ]
         };
         SV._reindexMovedReadingByMatching(2, 'P45');
-        // TODO: this ideally should be ['2.1', '4.1']
         assert.deepEqual(readings[1].text.map(x => x.index), ['2.1', '4.1'])
     });
 
@@ -50,7 +49,6 @@ QUnit.module('SV _reindexMovedReadingByMatching', function(hooks) {
             ]
         };
         SV._reindexMovedReadingByMatching(2, 'P45');
-        // TODO: this ideally should be ['2.1', '4.1']
         assert.deepEqual(readings[1].text.map(x => x.index), ['2.1', '4.1'])
     });
 
@@ -75,7 +73,6 @@ QUnit.module('SV _reindexMovedReadingByMatching', function(hooks) {
         };
 
         SV._reindexMovedReadingByMatching(2, 'P45');
-        // TODO: this ideally should be ['2.1', '4.1']
         assert.deepEqual(readings[1].text.map(x => x.index), ['2.1', '4.1'])
     });
 
@@ -222,7 +219,6 @@ QUnit.module('SV _reindexMovedReadingByMatching', function(hooks) {
             ]
         };
         SV._reindexMovedReadingByMatching(2, 'P45');
-        // TODO: would ideally be 2.1, 4.1, 6.1
         assert.deepEqual(readings[1].text.map(x => x.index), ['2.1', '4.1', '6.1'])
     });
 
@@ -248,7 +244,6 @@ QUnit.module('SV _reindexMovedReadingByMatching', function(hooks) {
             ]
         };
         SV._reindexMovedReadingByMatching(2, 'P45');
-        // TODO: would ideally be 2.1, 4.1, 6.1
         assert.deepEqual(readings[1].text.map(x => x.index), ['2.1', '4.1', '6.1'])
     });
 


### PR DESCRIPTION
**Please do not merge - just review**

This is the result of a feature request for better reindexing of words where the initial collation get chunks of a verse in the wrong place - this is usually caused by gaps or by duplication in the verse where sometimes the wrong instance of the text can get matched. The current system really only worked if words were moved individually and current editors are not happy with the amount of time that takes.

I would like to get this deployed soon in case it causes problems I haven't yet found - I need to do this in coordination with the editors so that they will definitely be actively using it in the first first few weeks. I will deploy this on the branch so we can quickly reverse it if problems are found and I can fix those new scenarios.

The changed matching option is only triggered when a reading is moved into an existing unit and at least half of the words in the resulting reading for that witness have undefined indexes, which means at least half of the words of that witness have been moved into the unit and the resulting reading does not match any of those already existing in the unit.  

In cases where the new matching reindexing function is triggered:
- A levenstein distance function is used to select the closest reading in the unit to the one we are reindexing. 
- The words in that reading are then compared using the 'interface' key and the matches are recorded. 
- The indexes of the new reading are then set as follows:
     - from the appropriate word in the closest reading if there is a match for that word 
     - by incremening the sub index of the previous word in the moved reading if there is no match
  
The levenstein distance algorithm is not used for the word matching because short words can make this innacurate and it would take more time for what needs to be a very quick function. 