### PR TITLE
Additional feature to allow removal of overlaps

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -33,7 +33,8 @@ jobs:
           node-version: '22'
       - name: Install dependencies and lint
         run: |
-          npm i eslint 
+          npm i eslint
+          npm i @eslint/js
           npm i @stylistic/eslint-plugin
           node_modules/eslint/bin/eslint.js static/CE_core/js/*.js --ignore-pattern "**/*.min.js"
 

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -35,6 +35,7 @@ jobs:
         run: |
           npm i eslint
           npm i @eslint/js
+          npm i globals
           npm i @stylistic/eslint-plugin
           node_modules/eslint/bin/eslint.js static/CE_core/js/*.js --ignore-pattern "**/*.min.js"
 

--- a/preprocessor.py
+++ b/preprocessor.py
@@ -160,7 +160,7 @@ class PreProcessor(Regulariser):
                         hand_to_transcript_map[reading['id']] = transcription_verse['transcription_identifier']
                     else:
                         hand_to_transcript_map[reading['id']] = transcription_verse['transcription']
-                    if len(reading['tokens']) == 0:
+                    if reading['tokens'] is None or len(reading['tokens']) == 0:
                         if 'gap_reading' in reading:
                             lac_hands.append(reading['id'])
                             self._add_to_special_categories(special_categories, reading)

--- a/static/CE_core/js/collation.js
+++ b/static/CE_core/js/collation.js
@@ -3942,10 +3942,12 @@ var CL = (function() {
         }
       }
       // update hand_id_map
-      for (const key in newData.hand_id_map) {
-        if (Object.prototype.hasOwnProperty.call(newData.hand_id_map, key)) {
-          if (!Object.prototype.hasOwnProperty.call(mainCollation.structure.hand_id_map, key)) {
-            mainCollation.structure.hand_id_map[key] = newData.hand_id_map[key];
+      if (addedWits.length > 0) {
+        for (const key in newData.hand_id_map) {
+          if (Object.prototype.hasOwnProperty.call(newData.hand_id_map, key)) {
+            if (!Object.prototype.hasOwnProperty.call(mainCollation.structure.hand_id_map, key)) {
+              mainCollation.structure.hand_id_map[key] = newData.hand_id_map[key];
+            }
           }
         }
       }
@@ -3973,6 +3975,7 @@ var CL = (function() {
           } else {
             if (newUnit === null) {
               omReading = null;
+              console.log(existingUnit)
               for (let i = 0; i < existingUnit.readings.length; i += 1) {
                 // NB: this last condition should not be needed but before 26/09/21 the code was incorrectly
                 // adding type="om" to readings even if they had text when they were combined/moved above an overlap
@@ -3983,7 +3986,7 @@ var CL = (function() {
                   omReading = existingUnit.readings[i];
                 }
               }
-  
+
               if (omReading) {
                 // addedWits is identifiers rather than sigla for readings so use hand_id_map here instead
                 // we can assume that basetext is om in both cases as it is the same text so the check of exisitng

--- a/static/CE_core/js/collation.js
+++ b/static/CE_core/js/collation.js
@@ -3918,7 +3918,7 @@ var CL = (function() {
       }
     },
 
-    _mergeCollationObjects: function(mainCollation, newData, addedWits, startIndex, endIndex) {
+    _mergeCollationObjects: function(mainCollation, newData, addedWits, startIndex, endIndex, adjoiningUnits) {
       /** This merges a new collation into an existing collation. This might be a full verse if we are in add witness
       /* mode or a small chunk of a verse if we are removing an overlapping unit.
       /* AddedWits should be an empty list if removing an overlapping unit.
@@ -4084,6 +4084,7 @@ var CL = (function() {
               newUnit.added = true;
               mainCollation.structure.apparatus.push(newUnit);
               mainCollation.structure.apparatus.sort(SV.compareFirstWordIndexes);
+
               before = null;
               after = null;
               for (let i = 0; i < mainCollation.structure.apparatus.length; i += 1) {
@@ -4093,6 +4094,12 @@ var CL = (function() {
                 if (mainCollation.structure.apparatus[i].start === newUnit.start + 1) {
                   after = mainCollation.structure.apparatus[i];
                 }
+              }
+              if (before === null && adjoiningUnits !== undefined) {
+                before = adjoiningUnits[0];
+              }
+              if (after === null && adjoiningUnits !== undefined) {
+                after = adjoiningUnits[1];
               }
               if (before && after && Object.prototype.hasOwnProperty.call(before, 'overlap_units') &&
                       Object.prototype.hasOwnProperty.call(after, 'overlap_units')) {

--- a/static/CE_core/js/collation.js
+++ b/static/CE_core/js/collation.js
@@ -3991,6 +3991,7 @@ var CL = (function() {
                       !Object.prototype.hasOwnProperty.call(existingUnit.readings[i], 'overlap_status') &&
                       existingUnit.readings[i].text.length === 0) {
                   omReading = existingUnit.readings[i];
+                  break;  // if we don't break here then we might end up with regularised oms as the hit if the basetext is om
                 }
               }
               if (omReading) {

--- a/static/CE_core/js/collation.js
+++ b/static/CE_core/js/collation.js
@@ -3246,6 +3246,15 @@ var CL = (function() {
         // default is false
         CL.project.showSelectAllVariantsOption = false;
       }
+      // setting for allowing overlap removal. On a setting because the call to collateX might not always be appropriate
+      if (Object.prototype.hasOwnProperty.call(project, 'allowOverlapRemoval')) {
+        CL.project.allowOverlapRemoval = project.allowOverlapRemoval;
+      } else if (Object.prototype.hasOwnProperty.call(CL.services, 'allowOverlapRemoval')) {
+        CL.project.allowOverlapRemoval = CL.services.allowOverlapRemoval;
+      } else {
+        // default is false (maintains existing behaviour)
+        CL.project.allowOverlapRemoval = false;
+      }
       // settings for get apparatus button in approved view
       if (Object.prototype.hasOwnProperty.call(project, 'showGetApparatusButton')) {
         CL.project.showGetApparatusButton = project.showGetApparatusButton;

--- a/static/CE_core/js/collation.js
+++ b/static/CE_core/js/collation.js
@@ -3919,8 +3919,11 @@ var CL = (function() {
     },
 
     _mergeCollationObjects: function(mainCollation, newData, addedWits, startIndex, endIndex) {
-      // start and end index must be supplied if we are merging a partial section (used when removing
-      // overlappingreadings) for full verse merges we can calculate from the data.
+      /** This merges a new collation into an existing collation. This might be a full verse if we are in add witness
+      /* mode or a small chunk of a verse if we are removing an overlapping unit.
+      /* AddedWits should be an empty list if removing an overlapping unit.
+      /* start and end index must be supplied if we are merging a partial section (used when removing
+      /* overlappingreadings) for full verse merges we can calculate from the data. */
       let index, newUnit, existingUnit, newUnits, existingUnits, newReadingText,
         matchingReadingFound, unitQueue, nextUnits, unit1, unit2, tempUnit, omReading,
         existingWitnesses, before, after, beforeIds, afterIds,
@@ -3964,7 +3967,6 @@ var CL = (function() {
         index = startIndex;
       } 
       while (index <= endIndex) {
-        // if new data has one then
         newUnits = CL._getUnitsByStartIndex(index, newData.apparatus);
         existingUnits = CL._getUnitsByStartIndex(index, mainCollation.structure.apparatus);
         if (newUnits.length === 0 && existingUnits.length === 0) {
@@ -3974,7 +3976,6 @@ var CL = (function() {
           newUnit = z < newUnits.length ? newUnits[z] : null;
           existingUnit = z < existingUnits.length ? existingUnits[z] : null;
           if (existingUnit !== null && (newData.lac_readings.length > 0 || newData.om_readings.length > 0)) {
-            console.log('I am here and will run now')
             CL._mergeNewLacOmVerseReadings(existingUnit, newData);
           }
           if (newUnit === null && existingUnit === null) {
@@ -3992,7 +3993,6 @@ var CL = (function() {
                   omReading = existingUnit.readings[i];
                 }
               }
-
               if (omReading) {
                 // addedWits is identifiers rather than sigla for readings so use hand_id_map here instead
                 // we can assume that basetext is om in both cases as it is the same text so the check of exisitng
@@ -4193,7 +4193,8 @@ var CL = (function() {
     },
 
     _mergeNewLacOmVerseReadings: function(unit, newData) {
-      /** Merge any lac/om verse readings from the new data into the unit or add if no appropriate reading exists */
+      /** Merge any lac/om verse readings from the new data into the provided unit or add a new reading if no
+       * appropriate reading exists. */
       let lacsAdded, omsAdded;
       if (newData.lac_readings.length > 0) {
         lacsAdded = false;

--- a/static/CE_core/js/collation.js
+++ b/static/CE_core/js/collation.js
@@ -3918,7 +3918,9 @@ var CL = (function() {
       }
     },
 
-    _mergeCollationObjects: function(mainCollation, newData, addedWits) {
+    _mergeCollationObjects: function(mainCollation, newData, addedWits, startIndex, endIndex) {
+      // start and end index must be supplied if we are merging a partial section (used when removing
+      // overlappingreadings) for full verse merges we can calculate from the data.
       let index, newUnit, existingUnit, newUnits, existingUnits, newReadingText,
         matchingReadingFound, unitQueue, nextUnits, unit1, unit2, tempUnit, omReading,
         existingWitnesses, before, after, beforeIds, afterIds,
@@ -3955,10 +3957,14 @@ var CL = (function() {
       // if in existing and not new add new as om/lac verse/om_verse
       // if in new and not existing all existing needs to be om lac verse/om verse
       // make reading for any combined or shared units and check against existing readings
-      index = 1;  // this refers to the position indicated by numbers under the basetext
-      while (index <= (newData.overtext[0].tokens.length * 2) + 1) {
+      if (startIndex === undefined) {
+        index = 1; // this refers to the position indicated by numbers under the basetext
+        endIndex = (newData.overtext[0].tokens.length * 2) + 1
+      } else {
+        index = startIndex;
+      } 
+      while (index <= endIndex) {
         // if new data has one then
-  
         newUnits = CL._getUnitsByStartIndex(index, newData.apparatus);
         existingUnits = CL._getUnitsByStartIndex(index, mainCollation.structure.apparatus);
         if (newUnits.length === 0 && existingUnits.length === 0) {
@@ -3975,7 +3981,6 @@ var CL = (function() {
           } else {
             if (newUnit === null) {
               omReading = null;
-              console.log(existingUnit)
               for (let i = 0; i < existingUnit.readings.length; i += 1) {
                 // NB: this last condition should not be needed but before 26/09/21 the code was incorrectly
                 // adding type="om" to readings even if they had text when they were combined/moved above an overlap

--- a/static/CE_core/js/collation.js
+++ b/static/CE_core/js/collation.js
@@ -2817,7 +2817,7 @@ var CL = (function() {
           CL.dataSettings.base_text = document.getElementById('base-text').value;
         } else {
           alert('You can only add witnesses if the project base text is currently the same as the one used for the ' +
-            'saved collation. This is not the case with yur data.\n\nTo add witnesses change the project base ' +
+            'saved collation. This is not the case with your data.\n\nTo add witnesses change the project base ' +
             'text to match the saved collations.');
           CL.returnToSummaryTable();
           return;
@@ -4009,12 +4009,18 @@ var CL = (function() {
                 }
                 index = existingUnit.end + 1;
               } else {
-                alert('The new witnesses could not be added this time due to a base text conflict.\n' +
+                if (addedWits.length > 0) { // then we are trying to add witnesses
+                  alert('The new witnesses could not be added this time due to a base text conflict.\n' +
                   'Please check that your current project base text is the same as that used for the saved ' +
                   'collations and then try again.');
-                spinner.removeLoadingOverlay();
-                CL.returnToSummaryTable();
-                return;
+                  spinner.removeLoadingOverlay();
+                  CL.returnToSummaryTable();
+                  return;
+                } else {
+                  alert('Something went wrong while trying to remove the overlap. You must reload this page and not continue editing.')
+                  spinner.removeLoadingOverlay();
+                  return;
+                }
               }
             } else if (existingUnit === null) {
               // then add a new unit and make sure any overlapped witnesses are separated appropriately

--- a/static/CE_core/js/collation.js
+++ b/static/CE_core/js/collation.js
@@ -4115,12 +4115,12 @@ var CL = (function() {
                 for (let j = 0; j < newUnit.readings.length; j += 1) {
                   matchingReadingFound = false;
                   newReadingText = CL.extractWitnessText(newUnit.readings[j]);
-  
                   for (let k = 0; k < existingUnit.readings.length; k += 1) {
                     if (!Object.prototype.hasOwnProperty.call(existingUnit.readings[k], 'overlap_status') &&
                       CL.extractWitnessText(existingUnit.readings[k]) === newReadingText) {
                       matchingReadingFound = true;
                       CL._mergeNewReading(existingUnit.readings[k], newUnit.readings[j]);
+                      break;  // if we don't break here then we might end up with regularised oms as the hit if the basetext is om
                     }
                   }
                   if (matchingReadingFound === false) {

--- a/static/CE_core/js/collation.js
+++ b/static/CE_core/js/collation.js
@@ -3918,7 +3918,7 @@ var CL = (function() {
       }
     },
 
-    _mergeCollationObjects: function(mainCollation, newData, addedWits, startIndex, endIndex, lacOmDetails) {
+    _mergeCollationObjects: function(mainCollation, newData, addedWits, startIndex, endIndex) {
       // start and end index must be supplied if we are merging a partial section (used when removing
       // overlappingreadings) for full verse merges we can calculate from the data.
       let index, newUnit, existingUnit, newUnits, existingUnits, newReadingText,
@@ -3975,7 +3975,7 @@ var CL = (function() {
           existingUnit = z < existingUnits.length ? existingUnits[z] : null;
           if (existingUnit !== null && (newData.lac_readings.length > 0 || newData.om_readings.length > 0)) {
             console.log('I am here and will run now')
-            CL._mergeNewLacOmVerseReadings(existingUnit, newData, lacOmDetails);
+            CL._mergeNewLacOmVerseReadings(existingUnit, newData);
           }
           if (newUnit === null && existingUnit === null) {
             index += 1;
@@ -4192,10 +4192,9 @@ var CL = (function() {
       }
     },
 
-    _mergeNewLacOmVerseReadings: function(unit, newData,lacOmDetails) {
+    _mergeNewLacOmVerseReadings: function(unit, newData) {
       /** Merge any lac/om verse readings from the new data into the unit or add if no appropriate reading exists */
       let lacsAdded, omsAdded;
-      console.log(lacOmDetails)
       if (newData.lac_readings.length > 0) {
         lacsAdded = false;
         for (let i = 0; i < unit.readings.length; i += 1) {

--- a/static/CE_core/js/collation.js
+++ b/static/CE_core/js/collation.js
@@ -3928,7 +3928,7 @@ var CL = (function() {
         matchingReadingFound, unitQueue, nextUnits, unit1, unit2, tempUnit, omReading,
         existingWitnesses, before, after, beforeIds, afterIds,
         sharedIds, overlappedWitnesses;
-  
+
       for (let i = 0; i < addedWits.length; i += 1) {
         if (mainCollation.data_settings.witness_list.indexOf(addedWits[i]) === -1) {
           mainCollation.data_settings.witness_list.push(addedWits[i]);
@@ -3975,13 +3975,15 @@ var CL = (function() {
         for (let z = 0; z < Math.max(newUnits.length, existingUnits.length); z += 1) {
           newUnit = z < newUnits.length ? newUnits[z] : null;
           existingUnit = z < existingUnits.length ? existingUnits[z] : null;
+          // first handle the om and lac verse stuff
           if (existingUnit !== null && (newData.lac_readings.length > 0 || newData.om_readings.length > 0)) {
             CL._mergeNewLacOmVerseReadings(existingUnit, newData);
           }
+          // now move onto the readings
           if (newUnit === null && existingUnit === null) {
             index += 1;
           } else {
-            if (newUnit === null) {
+            if (newUnit === null) { // then these witnesses are added as oms (lacOmfix might change that later)
               omReading = null;
               for (let i = 0; i < existingUnit.readings.length; i += 1) {
                 // NB: this last condition should not be needed but before 26/09/21 the code was incorrectly

--- a/static/CE_core/js/collation.js
+++ b/static/CE_core/js/collation.js
@@ -4129,7 +4129,7 @@ var CL = (function() {
                       CL.extractWitnessText(existingUnit.readings[k]) === newReadingText) {
                       matchingReadingFound = true;
                       CL._mergeNewReading(existingUnit.readings[k], newUnit.readings[j]);
-                      break;  // if we don't break here then we might end up with regularised oms as the hit if the basetext is om
+                      break;  // if we don't break here then we might end up with a regularised reading as a hit
                     }
                   }
                   if (matchingReadingFound === false) {
@@ -4171,6 +4171,7 @@ var CL = (function() {
                       CL.extractWitnessText(existingUnit.readings[k]) === newReadingText) {
                       matchingReadingFound = true;
                       CL._mergeNewReading(existingUnit.readings[k], unit1.readings[j]);
+                      break;  // if we don't break here then we might end up with a regularised reading as the hit
                     }
                   }
                   if (matchingReadingFound === false) {

--- a/static/CE_core/js/collation.js
+++ b/static/CE_core/js/collation.js
@@ -237,7 +237,8 @@ var CL = (function() {
         options = {};
       }
       text = [];
-      witnessText = [];
+      // eslint disabled because I think it is safer to assign a default here given the complex branching in this function
+      witnessText = [];  /* eslint-disable-line no-useless-assignment */
       // first fix the display of overlapped statuses
       if (Object.prototype.hasOwnProperty.call(reading, 'overlap_status') && reading.overlap_status !== 'duplicate') {
         if (test === true) {

--- a/static/CE_core/js/collation.js
+++ b/static/CE_core/js/collation.js
@@ -4131,6 +4131,7 @@ var CL = (function() {
                     existingUnit.readings.push(newUnit.readings[j]);
                   }
                 }
+                SV.unsplitUnitWitnesses(undefined, 'apparatus', existingUnit);
                 index = newUnit.end + 1;
               } else {
                 // no end agreement

--- a/static/CE_core/js/md5.js
+++ b/static/CE_core/js/md5.js
@@ -26,6 +26,7 @@
  **/
 
 /* exported MD5 */
+/* eslint-disable no-useless-assignment */
 var MD5 = function(string) {
 
   function RotateLeft(lValue, iShiftBits) {

--- a/static/CE_core/js/order_readings.js
+++ b/static/CE_core/js/order_readings.js
@@ -338,7 +338,6 @@ var OR = (function() {
       let temp, rowId, overlapped, hasContextMenu, readingClass, colspan, hand, readingLabel, readingSuffix, text, overlap;
       const html = [];
       const rowList = [];
-      hasContextMenu = true;
       overlap = false;
       if (id.indexOf('-app-') !== -1) {
         overlap = true;

--- a/static/CE_core/js/regularise.js
+++ b/static/CE_core/js/regularise.js
@@ -869,9 +869,11 @@ var RG = (function () {
         }
       }
       options.configs.algorithm_settings = algorithmSettings;
+
       if (Object.prototype.hasOwnProperty.call(CL.services, 'collatexHost')) {
         options.configs.collatexHost = CL.services.collatexHost;
       }
+
       if (output === 'add_witnesses' || output === 'remove_overlap') {
         options.configs.split_single_reading_units = true;
         resultCallback = function (data) {

--- a/static/CE_core/js/regularise.js
+++ b/static/CE_core/js/regularise.js
@@ -869,7 +869,6 @@ var RG = (function () {
         }
       }
       options.configs.algorithm_settings = algorithmSettings;
-      console.log(options.configs.algorithm_settings);
       if (output === 'remove_overlap') {
         options.configs.algorithm_settings.algorithm = 'dekker';
       }

--- a/static/CE_core/js/regularise.js
+++ b/static/CE_core/js/regularise.js
@@ -869,14 +869,9 @@ var RG = (function () {
         }
       }
       options.configs.algorithm_settings = algorithmSettings;
-      if (output === 'remove_overlap') {
-        options.configs.algorithm_settings.algorithm = 'dekker';
-      }
-
       if (Object.prototype.hasOwnProperty.call(CL.services, 'collatexHost')) {
         options.configs.collatexHost = CL.services.collatexHost;
       }
-
       if (output === 'add_witnesses' || output === 'remove_overlap') {
         options.configs.split_single_reading_units = true;
         resultCallback = function (data) {

--- a/static/CE_core/js/regularise.js
+++ b/static/CE_core/js/regularise.js
@@ -869,12 +869,16 @@ var RG = (function () {
         }
       }
       options.configs.algorithm_settings = algorithmSettings;
+      console.log(options.configs.algorithm_settings);
+      if (output === 'remove_overlap') {
+        options.configs.algorithm_settings.algorithm = 'dekker';
+      }
 
       if (Object.prototype.hasOwnProperty.call(CL.services, 'collatexHost')) {
         options.configs.collatexHost = CL.services.collatexHost;
       }
 
-      if (output === 'add_witnesses') {
+      if (output === 'add_witnesses' || output === 'remove_overlap') {
         options.configs.split_single_reading_units = true;
         resultCallback = function (data) {
           callback(data);

--- a/static/CE_core/js/set_variants.js
+++ b/static/CE_core/js/set_variants.js
@@ -5156,6 +5156,7 @@ var SV = (function() {
           if (SV.checkIds()[0]) {
             CL.addUnitAndReadingIds();
           }
+          SV.unprepareForOperation();
           SV.checkBugStatus('loaded', 'saved version');
           options.container = CL.container;
           SV.showSetVariants(options);

--- a/static/CE_core/js/set_variants.js
+++ b/static/CE_core/js/set_variants.js
@@ -789,7 +789,7 @@ var SV = (function() {
             readingList.push(null);  // needed so our list indexes stay alligned with the readings in the unit
             if (unit.readings[index].type === 'om') {
               unit.readings[index].witnesses.push.apply(unit.readings[index].witnesses, reading.witnesses);
-              reading = null;
+              reading = null; /* eslint-disable-line no-useless-assignment */
             }
           } else {
             readingList.push(text);
@@ -1428,7 +1428,6 @@ var SV = (function() {
       let subrowId, suffix, textString, highlightedClasses;
       const html = [];
       const rowList = [];
-      textString = '';
       if (Object.prototype.hasOwnProperty.call(reading, 'subreadings')) {
         html.push('<ul class="subreading-unit" id="subreading-unit-' + id + '-row-' + i + '">');
         for (const type in reading.subreadings) {
@@ -1725,7 +1724,6 @@ var SV = (function() {
         if (previousIndex === -1) {
           previousIndex = mainIndexes.indexOf(missingIndexes[i] - 2);
         }
-        nextIndex = -1
         nextIndex = mainIndexes.indexOf(missingIndexes[i] + 1);
         if (nextIndex === -1) {
           nextIndex = mainIndexes.indexOf(missingIndexes[i] + 2);

--- a/static/CE_core/js/set_variants.js
+++ b/static/CE_core/js/set_variants.js
@@ -4792,8 +4792,9 @@ var SV = (function() {
           const unitNumber = div.id.replace('drag-unit-', '');
           SV._addToUndoStack(CL.data);
           const dataCopy = JSON.parse(JSON.stringify(CL.data));
+          const settingsCopy = JSON.parse(JSON.stringify(CL.dataSettings));
           try {
-            SV._removeOverlap(unitNumber, dataCopy);
+            SV._removeOverlap(unitNumber, dataCopy, settingsCopy);
           } catch (err) {
             console.log(err);
             alert('The overlapping unit could not be deleted.');
@@ -4997,7 +4998,7 @@ var SV = (function() {
       }
     },
 
-    _removeOverlap: function(index, originalData) {
+    _removeOverlap: function(index, originalData, originalSettings) {
       /** Remove a current overlapping unit (activated from the right click context menu). Index is the id of the unit
        * being removed. The witnesses in this reading are removed from the section of text included in the overlap and
        * then that same chunk of text is recollated and merged back into the collation data. This reuses the code for
@@ -5006,6 +5007,9 @@ var SV = (function() {
        * The originalData argument is a copy of the full CL.data structure from before we start the process so we
        * can restore it if any errors happen along the way. Ideally the error could be thrown back to the place this
        * function is called but the callback chain doesn't seem to allow that.
+       *
+       * The originalSettings argument is a copy of the settings for the full unit which will be restored once the
+       * overlap removal is complete because we have to modify the witness list as part of the recollation process.
        */
       let apparatusNum, appId, witId, tokens;
       spinner.showLoadingOverlay();
@@ -5081,6 +5085,7 @@ var SV = (function() {
         if (lacOmDetails.length > 1) {
           alert('This overlapping unit cannot be removed because it contains different types of empty readings.');
           CL.data = originalData;
+          CL.dataSettings = originalSettings;
           SV.showSetVariantsData();
           return;
         }
@@ -5159,6 +5164,8 @@ var SV = (function() {
           SV.unprepareForOperation();
           SV.checkBugStatus('loaded', 'saved version');
           options.container = CL.container;
+          // restore the original data settings so we don't end up with a short witness list
+          CL.dataSettings = originalSettings;
           SV.showSetVariants(options);
         });
       });

--- a/static/CE_core/js/set_variants.js
+++ b/static/CE_core/js/set_variants.js
@@ -5303,6 +5303,7 @@ var SV = (function() {
           options.container = CL.container;
           // restore the original data settings so we don't end up with a short witness list
           CL.dataSettings = originalSettings;
+          CL._separateOverlapsInAddedUnits();
           SV.showSetVariants(options);
           document.getElementById('scroller').scrollLeft = scrollOffset[0];
           document.getElementById('scroller').scrollTop = scrollOffset[1];

--- a/static/CE_core/js/set_variants.js
+++ b/static/CE_core/js/set_variants.js
@@ -706,7 +706,7 @@ var SV = (function() {
      * so subreadings are always hidden and standoff readings are always main readings
      * after this unprepare_for_operation will run find subreadings
      * at the end of this operation standoff marked readings should still be main readings even if they share a parent with another reading
-     * we only need to combined readings that are not marked as standoff
+     * we only need to combine readings that are not marked as standoff
      * */
     unsplitUnitWitnesses: function(unitNum, appId, unit) {
       var text, reading, readingList, index, witness, standoffRecord, isStandoff;

--- a/static/CE_core/js/set_variants.js
+++ b/static/CE_core/js/set_variants.js
@@ -5104,8 +5104,6 @@ var SV = (function() {
           return;
         }
       }
-
-
       // remove the relevant witnesses from the section of the collation representing the overlap
       const wordRanges = {};
       const lacOmDetails = [];
@@ -5276,20 +5274,22 @@ var SV = (function() {
     _getWitnessIndexesForHand: function(units, hand) {
       /* Get the word index range in the requested hand that covers the full extent of the overlapping units provided */
       const indexes = [null, null, null];
+      let currentIndex;
       for (const unit of units) {
         for (const reading of unit.readings) {
           if (reading.witnesses.indexOf(hand) !== -1) { // this is the right reading
             for (const word of reading.text) {
-              if (Object.prototype.hasOwnProperty.call(word, hand)) {             
+              if (Object.prototype.hasOwnProperty.call(word, hand)) {
+                currentIndex = parseInt(word[hand].index)         
                 if (indexes[0] === null) {
-                  indexes[0] = word[hand].index;
-                  indexes[1] = word[hand].index;
+                  indexes[0] = currentIndex;
+                  indexes[1] = currentIndex;
                 } else {
                   if (word[hand].index < indexes[0]) {
-                    indexes[0] = word[hand].index;
+                    indexes[0] = currentIndex;
                   }
                   if (word[hand].index > indexes[1]) {
-                    indexes[1] = word[hand].index;
+                    indexes[1] = currentIndex;
                   }
                 }
               }

--- a/static/CE_core/js/set_variants.js
+++ b/static/CE_core/js/set_variants.js
@@ -5005,6 +5005,7 @@ var SV = (function() {
        */
       let apparatusNum, appId, witId, tokens;
       spinner.showLoadingOverlay();
+      SV.prepareForOperation();
       // find the correct apparatus
       if (index.match(/-app-/g)) {
         apparatusNum = parseInt(index.match(/\d+/g)[1], 10);

--- a/static/CE_core/js/set_variants.js
+++ b/static/CE_core/js/set_variants.js
@@ -5378,10 +5378,10 @@ var SV = (function() {
                   indexes[0] = currentIndex;
                   indexes[1] = currentIndex;
                 } else {
-                  if (word[hand].index < indexes[0]) {
+                  if (currentIndex < indexes[0]) {
                     indexes[0] = currentIndex;
                   }
-                  if (word[hand].index > indexes[1]) {
+                  if (currentIndex > indexes[1]) {
                     indexes[1] = currentIndex;
                   }
                 }

--- a/static/CE_core/js/set_variants.js
+++ b/static/CE_core/js/set_variants.js
@@ -4985,6 +4985,15 @@ var SV = (function() {
     },
 
     _removeOverlap: function(index, originalData) {
+      /** Remove a current overlapping unit (activated from the right click context menu). Index is the id of the unit
+       * being removed. The witnesses in this reading are removed from the section of text included in the overlap and
+       * then that same chunk of text is recollated and merged back into the collation data. This reuses the code for
+       * removing and adding witnesses from a collation where ever possible. 
+       * 
+       * The originalData argument is a copy of the full CL.data structure from before we start the process so we
+       * can restore it if any errors happen along the way. Ideally the error could be thrown back to the place this
+       * function is called but the callback chain doesn't seem to allow that.
+       */
       let apparatusNum, appId, witId, tokens;
       spinner.showLoadingOverlay();
       // find the correct apparatus
@@ -4993,7 +5002,7 @@ var SV = (function() {
         index = parseInt(index.match(/\d+/g)[0], 10);
         appId = 'apparatus' + apparatusNum;
       } else {
-        console.log('removeOverlap function makes no sense for a top line unit.');
+        // removeOverlap function makes no sense for a top line unit.
         return;
       }
       // remove the relevant witnesses from the section of the collation representing the overlap
@@ -5075,10 +5084,11 @@ var SV = (function() {
         };
         RG.runCollation(CL.collateData, 'remove_overlap', 0, function(data) {
           // set up
-          CL.data = data; // temporary assignment to allow all the cleaning functions to work
-          // now sort out the gaps if we have an all gap chunk - they will always come back as lac but
-          // we need to check the original overlap info and change things accordingly
-          // if we have got this far then we only have a single category of gap reading to worry about
+          CL.data = data; // temporary assignment to allow all the cleaning functions to work.
+          /** Now sort out the gaps if we have an all gap chunk - they will always come back as lac but
+           * we need to check the original overlap info and change things accordingly.
+           * NB: If we have got this far then we only have a single category of gap reading to worry about.
+           */
           if (data.special_categories && data.special_categories.length > 0) {
             const newReading = {
               'text': [],

--- a/static/CE_core/js/set_variants.js
+++ b/static/CE_core/js/set_variants.js
@@ -5102,7 +5102,6 @@ var SV = (function() {
           return;
         }
       }
-      // TODO: removal isn't following the newly crated ranges.
 
 
       // remove the relevant witnesses from the section of the collation representing the overlap

--- a/static/CE_core/js/set_variants.js
+++ b/static/CE_core/js/set_variants.js
@@ -5014,6 +5014,8 @@ var SV = (function() {
       let apparatusNum, appId, witId, tokens;
       spinner.showLoadingOverlay();
       SV.prepareForOperation();
+      const scrollOffset = [document.getElementById('scroller').scrollLeft,
+                            document.getElementById('scroller').scrollTop];
       // find the correct apparatus
       if (index.match(/-app-/g)) {
         apparatusNum = parseInt(index.match(/\d+/g)[1], 10);
@@ -5087,6 +5089,8 @@ var SV = (function() {
           CL.data = originalData;
           CL.dataSettings = originalSettings;
           SV.showSetVariantsData();
+          document.getElementById('scroller').scrollLeft = scrollOffset[0];
+          document.getElementById('scroller').scrollTop = scrollOffset[1];
           return;
         }
         const filteredCollationData = {'results': []};
@@ -5167,6 +5171,8 @@ var SV = (function() {
           // restore the original data settings so we don't end up with a short witness list
           CL.dataSettings = originalSettings;
           SV.showSetVariants(options);
+          document.getElementById('scroller').scrollLeft = scrollOffset[0];
+          document.getElementById('scroller').scrollTop = scrollOffset[1];
         });
       });
     },

--- a/static/CE_core/js/set_variants.js
+++ b/static/CE_core/js/set_variants.js
@@ -5091,7 +5091,7 @@ var SV = (function() {
         if (key != 'apparatus' && key.startsWith('apparatus') && key != appId) {
           for (let unit of CL.data[key]) {
             let cWitnesses = SV._getAllUnitWitnesses(unit).filter(x => x !== CL.data.overtext_name);
-            if (cWitnesses.filter(x => witnesses.indexOf(x) > 0).length > 0) {
+            if (cWitnesses.filter(x => witnesses.indexOf(x) !== -1).length > 0) {
               let cRange = SV._findOverlappedRange(unit._id);
               // if the overlap overlaps are current range add it to the candidates list
               if ((Math.max(range[0], cRange[0]) - Math.min(range[1], cRange[1])) <= 0) {

--- a/static/CE_core/js/set_variants.js
+++ b/static/CE_core/js/set_variants.js
@@ -4700,7 +4700,11 @@ var SV = (function() {
       if (menuName === 'unit') {
         document.getElementById('context-menu').innerHTML = '<li id="split-words"><span>Split words</span></li><li id="split-readings"><span>Split readings</span></li>';
       } else if (menuName === 'overlap-unit') {
-        document.getElementById('context-menu').innerHTML = '<li id="split-readings"><span>Split readings</span></li><li id="remove-overlap"><span>Remove overlap</span></li>';
+        if (CL.witnessEditingMode === false) {
+          document.getElementById('context-menu').innerHTML = '<li id="split-readings"><span>Split readings</span></li><li id="remove-overlap"><span>Remove overlap</span></li>';
+        } else {
+          document.getElementById('context-menu').innerHTML = '<li id="split-readings"><span>Split readings</span></li>';
+        }
       } else if (menuName === 'subreading') {
         document.getElementById('context-menu').innerHTML = '<li id="make-main-reading"><span>Make main reading</span></li>';
       } else if (menuName === 'split-duplicate-unit') {

--- a/static/CE_core/js/set_variants.js
+++ b/static/CE_core/js/set_variants.js
@@ -5120,7 +5120,7 @@ var SV = (function() {
                 data.lac_readings.splice(data.lac_readings.indexOf(hand), 1);
               }
             }
-          }          
+          }
           CL.lacOmFix();
           // copy so we can change CL.data without screwing this up
           data = JSON.parse(JSON.stringify(CL.data));
@@ -5145,8 +5145,8 @@ var SV = (function() {
             {'structure': {'apparatus': chunk, 'lac_readings': [], 'om_readings': []}},
             data,
             [],
-            data.apparatus[0].start,
-            data.apparatus[data.apparatus.length - 1].end
+            data.apparatus[0].start - 1,
+            data.apparatus[data.apparatus.length - 1].end + 1
           );
           CL.existingCollation.apparatus = preChunk.concat(mergedCollationChunk.structure.apparatus, postChunk);
           CL.data = JSON.parse(JSON.stringify(CL.existingCollation));

--- a/static/CE_core/js/set_variants.js
+++ b/static/CE_core/js/set_variants.js
@@ -4734,7 +4734,7 @@ var SV = (function() {
       if (menuName === 'unit') {
         document.getElementById('context-menu').innerHTML = '<li id="split-words"><span>Split words</span></li><li id="split-readings"><span>Split readings</span></li>';
       } else if (menuName === 'overlap-unit') {
-        if (CL.witnessEditingMode === false) {
+        if (CL.witnessEditingMode === false && CL.project.allowOverlapRemoval === true) {
           document.getElementById('context-menu').innerHTML = '<li id="split-readings"><span>Split readings</span></li><li id="remove-overlap"><span>Remove overlap</span></li>';
         } else {
           document.getElementById('context-menu').innerHTML = '<li id="split-readings"><span>Split readings</span></li>';

--- a/static/CE_core/js/set_variants.js
+++ b/static/CE_core/js/set_variants.js
@@ -3542,7 +3542,7 @@ var SV = (function() {
 
     _uniquifySeparatedOverlapWitnesses: function(splitAdditions) {
       /* Take the separated overlapped reading created in _separateIndividualOverlapWitnesses and combine them so each
-      witness appears only once. This is a separate function because we call _separateIndividualOverlapWitnesses and 
+      witness appears only once. This is a separate function because we call _separateIndividualOverlapWitnesses twice and 
       I'm not confident that this needs to happen in both places yet. */
       let uniqueSplitAdditions = [];
       let addedWitnesses = [];

--- a/static/CE_core/js/set_variants.js
+++ b/static/CE_core/js/set_variants.js
@@ -5123,10 +5123,11 @@ var SV = (function() {
           return;
         }
       }
-      /* remove the relevant witnesses from the section of the collation representing the overlap while also removing
-      /* any standoff regularisations for these witnesses in the units being removed in the top line (we only need to do
-      /* this for the top line because overlaps will be removed entirely and the standoff removed as part of the clean
-      /* up process for no longer applied regularisations) */
+      /** remove the relevant witnesses from the section of the collation representing the overlap while also removing
+       * any standoff regularisations for these witnesses in the units being removed in the top line (we only need to do
+       * this for the top line because overlaps will be removed entirely and the standoff removed as part of the clean
+       * up process for no longer applied regularisations)
+       */
       const wordRanges = {};
       const lacOmDetails = [];
       wordRanges['basetext'] = SV._getWitnessIndexesForHand(allOverlappingUnits, 'basetext');

--- a/static/CE_core/js/set_variants.js
+++ b/static/CE_core/js/set_variants.js
@@ -5226,6 +5226,7 @@ var SV = (function() {
           'lac_witnesses': lacWitnesses
         };
         RG.runCollation(CL.collateData, 'remove_overlap', 0, function(data) {
+          let before, after;
           // set up
           CL.data = data; // temporary assignment to allow all the cleaning functions to work.
           /** Now sort out the gaps if we have an all gap chunk - they will always come back as lac but
@@ -5283,12 +5284,21 @@ var SV = (function() {
               i += 1;
             }
           }
+          before = null;
+          after = null;
+          if (preChunk.length > 0) {
+            before = preChunk[preChunk.length - 1];
+          }
+          if (postChunk.length > 0) {
+            after = postChunk[0];
+          }
           const mergedCollationChunk = CL._mergeCollationObjects(
             {'structure': {'apparatus': chunk, 'lac_readings': [], 'om_readings': []}},
             data,
             [],
             data.apparatus[0].start - 1,
-            data.apparatus[data.apparatus.length - 1].end + 1
+            data.apparatus[data.apparatus.length - 1].end + 1,
+            [before, after]
           );
           CL.existingCollation.apparatus = preChunk.concat(mergedCollationChunk.structure.apparatus, postChunk);
           CL.data = JSON.parse(JSON.stringify(CL.existingCollation));

--- a/static/CE_core/js/set_variants.js
+++ b/static/CE_core/js/set_variants.js
@@ -5143,7 +5143,7 @@ var SV = (function() {
           CL.removeNullItems(CL.data[currentAppId]);
         }
         // now remove from the top line
-        for (let i = range[0]; i <= range[1]; i += 1) {       
+        for (let i = range[1]; i >= range[0]; i -= 1) {
           CL.data.apparatus[i] = SV._removeWitnessFromUnitAndSortRemainder(CL.data.apparatus[i], hand, 'apparatus');
           CL.removeNullItems(CL.data.apparatus);
           SV._deleteStandoffRegularisation(CL.data.apparatus[i], hand);

--- a/static/CE_core/js/set_variants.js
+++ b/static/CE_core/js/set_variants.js
@@ -5065,31 +5065,39 @@ var SV = (function() {
             data = JSON.parse(JSON.stringify(CL.data));
             console.log(CL.existingCollation);
             const originalApparatus = JSON.parse(JSON.stringify(CL.existingCollation.apparatus));
-            const preChunk = originalApparatus.slice(0, range[0] + 1);
-            const postChunk = originalApparatus.slice(range[1]);
+            const preChunk = originalApparatus.slice(0, range[0]);
+            const postChunk = originalApparatus.slice(range[1]+ 1);
             // add the data back in
             // just get the chunk we need to change
-            //const chunk = CL.existingCollation.apparatus.slice(range[0], range[1] + 1);
-            
-            console.log(CL.existingCollation);
-            const mergedCollationChunk = CL._mergeCollationObjects({'structure': CL.existingCollation}, data, []);
-            console.log(mergedCollationChunk);
-            if (mergedCollationChunk[0].start === 1 && preChunk.length > 0) {
-              if (preChunk[preChunk.length -1].end%2 === 0) {
-                mergedCollationChunk[0].start === preChunk[preChunk.length -1].end + 1;
-                mergedCollationChunk[0].end === preChunk[preChunk.length -1].end + 1;
-                mergedCollationChunk[0].first_word_index = mergedCollationChunk[0].end + '.1';
+            const chunk = CL.existingCollation.apparatus.slice(range[0], range[1] + 1);
+            if (data.apparatus[0].start === 1 && preChunk.length > 0) {
+              if (preChunk[preChunk.length -1].end % 2 === 0) {
+                data.apparatus[0].start = preChunk[preChunk.length -1].end + 1;
+                data.apparatus[0].end = preChunk[preChunk.length -1].end + 1;
+                data.apparatus[0].first_word_index = data.apparatus[0].end + '.1';
               } else {
-                mergedCollationChunk[0].start === preChunk[preChunk.length -1].end;
-                mergedCollationChunk[0].end === preChunk[preChunk.length -1].end;
-                mergedCollationChunk[0].first_word_index = SV._incrementSubIndex(preChunk[preChunk.length -1].first_word_index, 1);
+                data.apparatus[0].start = preChunk[preChunk.length -1].end;
+                data.apparatus[0].end = preChunk[preChunk.length -1].end;
+                data.apparatus[0].first_word_index = SV._incrementSubIndex(preChunk[preChunk.length -1].first_word_index, 1);
               }
             }
-            console.log(mergedCollationChunk);
-            CL.existingCollation.apparatus = preChunk.concat(mergedCollationChunk, postChunk);
+            const mergedCollationChunk = CL._mergeCollationObjects(
+              {'structure': {'apparatus': chunk, 'lac_readings': [], 'om_readings': []}}, data, [], data.apparatus[0].start, data.apparatus[data.apparatus.length - 1].end
+            );
+            CL.existingCollation.apparatus = preChunk.concat(mergedCollationChunk.structure.apparatus, postChunk);
             console.log(CL.existingCollation.apparatus);
             CL.data = JSON.parse(JSON.stringify(CL.existingCollation));
-            SV.showSetVariantsData();
+            console.log('#############')
+            console.log(JSON.parse(JSON.stringify(CL.data)));
+            console.log('#############')
+            const options = {};
+            if (SV.checkIds()[0]) {
+              CL.addUnitAndReadingIds();
+            }
+            SV.checkBugStatus('loaded', 'saved version');
+            options.container = CL.container;
+            SV.showSetVariants(options);
+            
           });
         }  
       });

--- a/static/CE_core/js/set_variants.js
+++ b/static/CE_core/js/set_variants.js
@@ -5133,6 +5133,7 @@ var SV = (function() {
       const wordRanges = {};
       const lacOmDetails = [];
       wordRanges['basetext'] = SV._getWitnessIndexesForHand(allOverlappingUnits, 'basetext');
+      let nullCount = 0;
       for (const hand of witnesses) {
         wordRanges[hand] = SV._getWitnessIndexesForHand(allOverlappingUnits, hand);
         // here we need to remove the witness and return the unit for all overlapping units - we need to find appId and index for each one first!
@@ -5142,13 +5143,18 @@ var SV = (function() {
           CL.data[currentAppId][currentIndex] = SV._removeWitnessFromUnitAndSortRemainder(currentOverlappingUnit, hand, currentAppId);
           CL.removeNullItems(CL.data[currentAppId]);
         }
-        // now remove from the top line
+        // now remove from the top line while keeping a count of any top line untis that are removed.
         for (let i = range[1]; i >= range[0]; i -= 1) {
           CL.data.apparatus[i] = SV._removeWitnessFromUnitAndSortRemainder(CL.data.apparatus[i], hand, 'apparatus');
+          if (CL.data.apparatus[i] === null) {
+            nullCount += 1;
+          }
           CL.removeNullItems(CL.data.apparatus);
           SV._deleteStandoffRegularisation(CL.data.apparatus[i], hand);
         }
       }
+      // recalculate the final unit in the range based on any that have been removed.
+      range[1] = range[1] - nullCount;
       // now add them back in
       // get the data and split out just the sections we need (details in wordRanges)
       CL.dataSettings.witness_list = [];

--- a/static/CE_core/js/set_variants.js
+++ b/static/CE_core/js/set_variants.js
@@ -5292,8 +5292,13 @@ var SV = (function() {
           if (postChunk.length > 0) {
             after = postChunk[0];
           }
+          const baseCollationChunk = {
+            'structure': {
+              'apparatus': chunk, 'lac_readings': originalData.lac_readings, 'om_readings': originalData.om_readings
+            }
+          };
           const mergedCollationChunk = CL._mergeCollationObjects(
-            {'structure': {'apparatus': chunk, 'lac_readings': [], 'om_readings': []}},
+            baseCollationChunk,
             data,
             [],
             data.apparatus[0].start - 1,

--- a/static/CE_core/js/set_variants.js
+++ b/static/CE_core/js/set_variants.js
@@ -708,10 +708,12 @@ var SV = (function() {
      * at the end of this operation standoff marked readings should still be main readings even if they share a parent with another reading
      * we only need to combined readings that are not marked as standoff
      * */
-    unsplitUnitWitnesses: function(unitNum, appId) {
-      var text, unit, reading, readingList, index, witness, standoffRecord, isStandoff;
+    unsplitUnitWitnesses: function(unitNum, appId, unit) {
+      var text, reading, readingList, index, witness, standoffRecord, isStandoff;
       readingList = [];
-      unit = CL.data[appId][unitNum];
+      if (unit === undefined) {
+        unit = CL.data[appId][unitNum];
+      }
       SV._removeSeparatedWitnessData(appId, unit._id);
 
       for (let i = 0; i < unit.readings.length; i += 1) {

--- a/static/CE_core/js/set_variants.js
+++ b/static/CE_core/js/set_variants.js
@@ -5030,6 +5030,25 @@ var SV = (function() {
       }
     },
 
+    _deleteStandoffRegularisation: function(unit, witness) {
+      for (const key in CL.data.marked_readings) {
+        if (Object.prototype.hasOwnProperty.call(CL.data.marked_readings, key)) {
+          for (let i = 0; i < CL.data.marked_readings[key].length; i += 1) {
+            if (CL.data.marked_readings[key][i].start === unit.start && 
+                    CL.data.marked_readings[key][i].end === unit.end) { //if this is the right unit
+              if (CL.data.marked_readings[key][i].witness === witness) { //and we have the right witness
+                CL.data.marked_readings[key][i] = null;
+              }
+            }
+          }
+          CL.data.marked_readings[key] = CL.removeNullItems(CL.data.marked_readings[key]);
+          if (CL.data.marked_readings[key].length === 0) {
+            delete CL.data.marked_readings[key];
+          }
+        }
+      }
+    },
+
     _removeOverlap: function(index, originalData, originalSettings) {
       /** Remove a current overlapping unit (activated from the right click context menu). Index is the id of the unit
        * being removed. The witnesses in this reading are removed from the section of text included in the overlap and
@@ -5104,7 +5123,10 @@ var SV = (function() {
           return;
         }
       }
-      // remove the relevant witnesses from the section of the collation representing the overlap
+      /* remove the relevant witnesses from the section of the collation representing the overlap while also removing
+      /* any standoff regularisations for these witnesses in the units being removed in the top line (we only need to do
+      /* this for the top line because overlaps will be removed entirely and the standoff removed as part of the clean
+      /* up process for no longer applied regularisations) */
       const wordRanges = {};
       const lacOmDetails = [];
       wordRanges['basetext'] = SV._getWitnessIndexesForHand(allOverlappingUnits, 'basetext');
@@ -5121,6 +5143,7 @@ var SV = (function() {
         for (let i = range[0]; i <= range[1]; i += 1) {       
           CL.data.apparatus[i] = SV._removeWitnessFromUnitAndSortRemainder(CL.data.apparatus[i], hand, 'apparatus');
           CL.removeNullItems(CL.data.apparatus);
+          SV._deleteStandoffRegularisation(CL.data.apparatus[i], hand);
         }
       }
       // now add them back in

--- a/static/CE_core/js/set_variants.js
+++ b/static/CE_core/js/set_variants.js
@@ -1036,6 +1036,15 @@ var SV = (function() {
             }
           }
           console.log('witnesses missing in unit ' + i);
+          const missing = [];
+          for (const sigla of totalSigla) {
+            if (witnesses.indexOf(sigla) === -1) {
+              if (sigla !== null) {
+                missing.push(sigla);
+              }
+            }
+          }
+          console.log('missing witnesses are ' + missing.join(', '));
           return false;
         }
       }

--- a/static/CE_core/js/set_variants.js
+++ b/static/CE_core/js/set_variants.js
@@ -5115,7 +5115,6 @@ var SV = (function() {
           let [currentAppId, currentIndex] = SV._getAppIdAndIndexByOverlapId(currentOverlappingUnit._id);
           // remove from the current overlap unit - needs to be returned because it isn't passing as reference through the full function chain
           CL.data[currentAppId][currentIndex] = SV._removeWitnessFromUnitAndSortRemainder(currentOverlappingUnit, hand, currentAppId);
-          //CL.data[appId][index] = SV._removeWitnessFromUnitAndSortRemainder(overlapUnit, hand, appId);
           CL.removeNullItems(CL.data[currentAppId]);
         }
         // now remove from the top line
@@ -5137,14 +5136,20 @@ var SV = (function() {
       CL.services.getUnitData(CL.context, CL.dataSettings.witness_list, function (collationData) {
         const witnessesInData = [];
         for (let entry of collationData.results) {
-          if (entry.witnesses === null) {  // this will be an om verse
+          if (entry.witnesses === null) {  // this will be an om verse (single hand in the MS)
             witnessesInData.push(entry.siglum);
           } else {
             for (let j = 0; j < entry.witnesses.length; j += 1) {
               // collate just the hands we need
               witId = entry.witnesses[j].id;
               if (witId !== CL.data.overtext_name && witnesses.indexOf(witId) === -1) {
-                entry.witnesses[j] = null;
+                entry.witnesses[j] = null; // remove the witness if it isn't a witness in the overlap being removed
+              } else if (entry.witnesses[j].tokens.length === 0) { // then this hand is om_verse
+                entry.witnesses[j].tokens = null;              
+                if (lacOmDetails.indexOf(wordRanges[witId][2].join('|')) === -1) {
+                  lacOmDetails.push(wordRanges[witId][2].join('|'));
+                }
+                witnessesInData.push(witId);
               } else if (witId !== CL.data.overtext_name && wordRanges[witId][2] !== null) { // this is lac or om for the chunk so don't collate
                 entry.witnesses[j].tokens = [];
                 entry.witnesses[j].gap_reading = 'for_fixing';

--- a/static/CE_core/js/set_variants.js
+++ b/static/CE_core/js/set_variants.js
@@ -5228,15 +5228,28 @@ var SV = (function() {
           // add the data back in
           // just get the chunk we need to change
           const chunk = CL.existingCollation.apparatus.slice(range[0], range[1] + 1);
+          // renumber units that start with 1 to the gap before the first non-gap unit
           if (data.apparatus[0].start === 1 && preChunk.length > 0) {
-            if (preChunk[preChunk.length -1].end % 2 === 0) {
-              data.apparatus[0].start = preChunk[preChunk.length -1].end + 1;
-              data.apparatus[0].end = preChunk[preChunk.length -1].end + 1;
-              data.apparatus[0].first_word_index = data.apparatus[0].end + '.1';
-            } else {
-              data.apparatus[0].start = preChunk[preChunk.length -1].end;
-              data.apparatus[0].end = preChunk[preChunk.length -1].end;
-              data.apparatus[0].first_word_index = SV._incrementSubIndex(preChunk[preChunk.length -1].first_word_index, 1);
+            let i = 0;
+            while(data.apparatus[i].start === 1) {
+              if (preChunk[preChunk.length -1].end % 2 === 0) { // this is an even numbered unit 
+                data.apparatus[i].start = preChunk[preChunk.length -1].end + 1;
+                data.apparatus[i].end = preChunk[preChunk.length -1].end + 1;
+                if (i === 0) {
+                  data.apparatus[i].first_word_index = data.apparatus[i].end + '.1';
+                } else {
+                  data.apparatus[i].first_word_index = SV._incrementSubIndex(data.apparatus[i - 1].first_word_index, 1);
+                }
+              } else { // this is an addition unit
+                data.apparatus[i].start = preChunk[preChunk.length -1].end;
+                data.apparatus[i].end = preChunk[preChunk.length -1].end;
+                if (i === 0) {
+                  data.apparatus[i].first_word_index = SV._incrementSubIndex(preChunk[preChunk.length -1].first_word_index, 1);
+                } else {
+                  data.apparatus[i].first_word_index = SV._incrementSubIndex(data.apparatus[i - 1].first_word_index, 1);
+                }
+              }
+              i += 1;
             }
           }
           const mergedCollationChunk = CL._mergeCollationObjects(

--- a/static/CE_core/js/set_variants.js
+++ b/static/CE_core/js/set_variants.js
@@ -4777,6 +4777,7 @@ var SV = (function() {
             return true;
           });
           const unitNumber = div.id.replace('drag-unit-', '');
+          SV._addToUndoStack(CL.data);
           const dataCopy = JSON.parse(JSON.stringify(CL.data));
           try {
             SV._removeOverlap(unitNumber, dataCopy);


### PR DESCRIPTION
**This is one we will deploy on the branch before merging to get some real life testing done so please just review don't merge.**

This adds new functionality which allows users to remove overlapping units. I have been asked for this a lot and have consistently said no because I was worried about the complexity and thought it would introduce more problems than it solved. Then I had an idea which would mean most of the code was repurposed from existing, reasonably well used code so I decided to give it a go.

The code I am repurposing allows users to remove a particular witness from a verse and add add a new witness to a verse. I have repurposed this by using the removal code to remove the witnesses involved in the overlapping unit from the chunk of the verse covered by the overlapping unit only and then use the code to add a new witness to add that same witness back into that chunk.

Changes to regularise.js are minimal and just to run the appropriate callback rather than follow the standard collation display process.

Changes to collation.js 
+ changes to _mergeCollationObjects which allows it to work only on a small chunk (between the provided start and end indexes.
+ fix a bug in _mergeNewLacOmVerseReadings function which is why there are so many changes (so much for repurposing unbuggy code!)

Changes to set_variants.js
+ Adds the menu item to the right click context menu for overlapping units
+ Adds the handler for that menu item in a try/catch in the hope that it might recover if errors are thrown - although it is unlikely because of the function embedding because of the callback chains - this code is not yet on promises.
+ Adds a new function _removeOverlap which controls the process of removing and readding the witnesses and if known issues occur it will reset it back to the starting state.

