### PR TITLE
Restructure the exporter functions a little

### DIFF
--- a/exporter.py
+++ b/exporter.py
@@ -405,7 +405,11 @@ class Exporter(RestructureExportDataMixin, object):
                                 if len(wits) > 0:
                                     readings = True
                                     subreading_label = self.get_subreading_label(reading['label'], subreading)
-                                    app.append(self.make_reading(subreading, i, subreading_label, wits, True, subreading['suffix']))
+                                    app.append(
+                                        self.make_reading(
+                                            subreading, i, subreading_label, wits, True, subreading['suffix']
+                                        )
+                                    )
                         else:
                             for key in reading['subreadings']:
                                 for subreading in reading['subreadings'][key]:
@@ -434,7 +438,11 @@ class Exporter(RestructureExportDataMixin, object):
                                 if len(wits) > 0:
                                     readings = True
                                     subreading_label = self.get_subreading_label(reading['label'], subreading)
-                                    app.append(self.make_reading(subreading, i, subreading_label, wits, True, subreading['suffix']))
+                                    app.append(
+                                        self.make_reading(
+                                            subreading, i, subreading_label, wits, True, subreading['suffix']
+                                        )
+                                    )
                         else:
                             for key in reading['subreadings']:
                                 for subreading in reading['subreadings'][key]:

--- a/exporter.py
+++ b/exporter.py
@@ -422,14 +422,15 @@ class Exporter(RestructureExportDataMixin, object):
         """Create the subreading XML for this reading and add it to the provided apparatus unit.
 
         Args:
-            reading (_type_): _description_
-            index_position (_type_): _description_
-            app (_type_): _description_
-            missing (_type_): _description_
-            readings (_type_): _description_
+            reading (dict): The JSON dictionary representing a reading.
+            index_position (int): The position of this reading in the readings of this unit.
+            app (xml.etree.ElementTree.Element): The XML tree being created for this apparatus unit.
+            missing (list): A list of witnesses to remove from the apparatus (because they are being reported separately
+                or of no interest for another reason.)
+            readings (bool): A boolean to determine if this unit should be included in the apparatus output.
 
         Returns:
-            bool: _description_
+            bool: The reading boolean updated if required.
         """
         for key in reading['subreadings']:
             for subreading in reading['subreadings'][key]:

--- a/exporter.py
+++ b/exporter.py
@@ -399,13 +399,21 @@ class Exporter(RestructureExportDataMixin, object):
                         app.append(self.make_reading(reading, i, reading['label'], wits, subtype=subtype))
 
                     if 'subreadings' in reading:
-                        for key in reading['subreadings']:
-                            for subreading in reading['subreadings'][key]:
+                        if isinstance(reading['subreadings'], list):
+                            for subreading in reading['subreadings']:
                                 wits = self.get_witnesses(subreading, missing)
                                 if len(wits) > 0:
                                     readings = True
                                     subreading_label = self.get_subreading_label(reading['label'], subreading)
-                                    app.append(self.make_reading(subreading, i, subreading_label, wits, True, key))
+                                    app.append(self.make_reading(subreading, i, subreading_label, wits, True, subreading['suffix']))
+                        else:
+                            for key in reading['subreadings']:
+                                for subreading in reading['subreadings'][key]:
+                                    wits = self.get_witnesses(subreading, missing)
+                                    if len(wits) > 0:
+                                        readings = True
+                                        subreading_label = self.get_subreading_label(reading['label'], subreading)
+                                        app.append(self.make_reading(subreading, i, subreading_label, wits, True, key))
 
                 else:
                     if (len(wits) > 0 or reading['label'] == 'a' or 'subreadings' in reading) and (
@@ -420,13 +428,21 @@ class Exporter(RestructureExportDataMixin, object):
                         app.append(self.make_reading(reading, i, reading['label'], wits, subtype=subtype))
 
                     if 'subreadings' in reading:
-                        for key in reading['subreadings']:
-                            for subreading in reading['subreadings'][key]:
+                        if isinstance(reading['subreadings'], list):
+                            for subreading in reading['subreadings']:
                                 wits = self.get_witnesses(subreading, missing)
                                 if len(wits) > 0:
                                     readings = True
                                     subreading_label = self.get_subreading_label(reading['label'], subreading)
-                                    app.append(self.make_reading(subreading, i, subreading_label, wits, True, key))
+                                    app.append(self.make_reading(subreading, i, subreading_label, wits, True, subreading['suffix']))
+                        else:
+                            for key in reading['subreadings']:
+                                for subreading in reading['subreadings'][key]:
+                                    wits = self.get_witnesses(subreading, missing)
+                                    if len(wits) > 0:
+                                        readings = True
+                                        subreading_label = self.get_subreading_label(reading['label'], subreading)
+                                        app.append(self.make_reading(subreading, i, subreading_label, wits, True, key))
 
             if readings:
                 app_list.append(app)

--- a/exporter.py
+++ b/exporter.py
@@ -399,26 +399,7 @@ class Exporter(RestructureExportDataMixin, object):
                         app.append(self.make_reading(reading, i, reading['label'], wits, subtype=subtype))
 
                     if 'subreadings' in reading:
-                        if isinstance(reading['subreadings'], list):
-                            for subreading in reading['subreadings']:
-                                wits = self.get_witnesses(subreading, missing)
-                                if len(wits) > 0:
-                                    readings = True
-                                    subreading_label = self.get_subreading_label(reading['label'], subreading)
-                                    app.append(
-                                        self.make_reading(
-                                            subreading, i, subreading_label, wits, True, subreading['suffix']
-                                        )
-                                    )
-                        else:
-                            for key in reading['subreadings']:
-                                for subreading in reading['subreadings'][key]:
-                                    wits = self.get_witnesses(subreading, missing)
-                                    if len(wits) > 0:
-                                        readings = True
-                                        subreading_label = self.get_subreading_label(reading['label'], subreading)
-                                        app.append(self.make_reading(subreading, i, subreading_label, wits, True, key))
-
+                        readings = self.get_subreadings(reading, i, app, missing, readings)
                 else:
                     if (len(wits) > 0 or reading['label'] == 'a' or 'subreadings' in reading) and (
                         'overlap_status' not in reading
@@ -432,29 +413,32 @@ class Exporter(RestructureExportDataMixin, object):
                         app.append(self.make_reading(reading, i, reading['label'], wits, subtype=subtype))
 
                     if 'subreadings' in reading:
-                        if isinstance(reading['subreadings'], list):
-                            for subreading in reading['subreadings']:
-                                wits = self.get_witnesses(subreading, missing)
-                                if len(wits) > 0:
-                                    readings = True
-                                    subreading_label = self.get_subreading_label(reading['label'], subreading)
-                                    app.append(
-                                        self.make_reading(
-                                            subreading, i, subreading_label, wits, True, subreading['suffix']
-                                        )
-                                    )
-                        else:
-                            for key in reading['subreadings']:
-                                for subreading in reading['subreadings'][key]:
-                                    wits = self.get_witnesses(subreading, missing)
-                                    if len(wits) > 0:
-                                        readings = True
-                                        subreading_label = self.get_subreading_label(reading['label'], subreading)
-                                        app.append(self.make_reading(subreading, i, subreading_label, wits, True, key))
-
+                        readings = self.get_subreadings(reading, i, app, missing, readings)
             if readings:
                 app_list.append(app)
         return app_list
+
+    def get_subreadings(self, reading, index_position, app, missing, readings):
+        """Create the subreading XML for this reading and add it to the provided apparatus unit.
+
+        Args:
+            reading (_type_): _description_
+            index_position (_type_): _description_
+            app (_type_): _description_
+            missing (_type_): _description_
+            readings (_type_): _description_
+
+        Returns:
+            bool: _description_
+        """
+        for key in reading['subreadings']:
+            for subreading in reading['subreadings'][key]:
+                wits = self.get_witnesses(subreading, missing)
+                if len(wits) > 0:
+                    readings = True
+                    subreading_label = self.get_subreading_label(reading['label'], subreading)
+                    app.append(self.make_reading(subreading, index_position, subreading_label, wits, True, key))
+        return readings
 
     def get_overtext_data(self, entry):
         """Get the overtext data in a specfic format.


### PR DESCRIPTION
This makes a small change to exporter which moves the subreading generation out into a separate function.

The reason behind this is so that the subreading generation function can be overwritten in an inheriting class (specifically the CBGM exporter from the apparatus editor) by which time the subreading structure as changed to a list from a dictionary as part of the apparatus compilation process. 

It also reduces a little bit of code duplication in this file which is an additional benefit.

I'm not happy with the amount of things I have to pass into the new function which is why I had not separated it out previously however, this now seems more preferable than adding the code to process two different kinds of subreading structure to this very low level editor which is for an independently released verison of the code that will might never need to deal with subreadings structured as a list (if ever it does then this code can be changed). 