### PR TITLE
bug fix for duplicate oms being added when splitting top line above a…

### DIFF
--- a/static/CE_core/js/set_variants.js
+++ b/static/CE_core/js/set_variants.js
@@ -3542,7 +3542,7 @@ var SV = (function() {
 
     _uniquifySeparatedOverlapWitnesses: function(splitAdditions) {
       /* Take the separated overlapped reading created in _separateIndividualOverlapWitnesses and combine them so each
-      witness appears only once. This is a separate function because we call _separateIndividualOverlapWitnesses and 
+      witness appears only once. This is a separate function because we call _separateIndividualOverlapWitnesses twice and 
       I'm not confident that this needs to happen in both places yet. */
       let uniqueSplitAdditions = [];
       let addedWitnesses = [];


### PR DESCRIPTION
This addresses this bug https://gitlab.bham.ac.uk/smithcy-wce-data/itsee_bugs/-/issues/115.

When words are split over overlapping units and involved in more than overlapping unit at a particular index point then the code was over adding 'om' readings, basically adding a new one for each of the overlaps it was involved in. This fix adds a function which essentially combined the witnesses at each index point before adding the om readings so only a single ones is added.  