### PR TITLE
bug fix for duplicate oms being added when splitting top line above a…

### DIFF
--- a/static/CE_core/js/set_variants.js
+++ b/static/CE_core/js/set_variants.js
@@ -5102,7 +5102,6 @@ var SV = (function() {
           return;
         }
       }
-      // TODO: removal isn't following the newly crated ranges.
 
 
       // remove the relevant witnesses from the section of the collation representing the overlap


### PR DESCRIPTION
We recently added a feature to allow users to remove overlapping units from a collation.

We do this by removing the witnesses and readding them. I found a scendario where sometimes a witness is involved in more that one overlapping unit and sometimes those units overlap each other. In these cases the removal was not working correctly.

This fixes the problem by removing and re-adding witnesses from the full extent of any overlapping units which overlap the one the user asked to remove (if any of the witnesses are shared). The user gets a warning and is asked to confirm before this goes ahead. 