### PR TITLE
1cor overlap removal combining fix

### DIFF
--- a/static/CE_core/js/collation.js
+++ b/static/CE_core/js/collation.js
@@ -1327,10 +1327,15 @@ var CL = (function() {
       // first strip all the empty units displaying gaps and then recreate the ones we still need
       CL._cleanExtraGaps();
       CL._createExtraGaps();
+      console.log('@@@@@@@@@@')
+      console.log(JSON.parse(JSON.stringify(CL.data)))
       const apparatus = CL.data.apparatus;
       for (let i = 0; i < apparatus.length; i += 1) { // loop through units
         extraReadings = [];
         for (let j = 0; j < apparatus[i].readings.length; j += 1) { // loop through readings
+          if (i === 2) {
+            console.log(JSON.parse(JSON.stringify(apparatus[i].readings[j])))
+          }
           // if this is reading contains an empty reading and if this isn't a whole verse lac or whole verse om
           if (CL._containsEmptyReading(apparatus[i].readings[j]) &&  // includes subreadings and SR_text
                     apparatus[i].readings[j].type !== 'lac_verse' &&
@@ -1341,8 +1346,16 @@ var CL = (function() {
             }
             // gets all witnesses that have an empty reading including those in subreadings
             emptyWitnesses = CL._getAllEmptyReadingWitnesses(apparatus[i].readings[j]);
+            if (i === 2) {
+              console.log('empty witnesses')
+              console.log(JSON.parse(JSON.stringify(emptyWitnesses)))
+            }
             // get all the witnesses for the reading
             witnesses = CL.getAllReadingWitnesses(apparatus[i].readings[j]);
+            if (i === 2) {
+              console.log('witnesses')
+              console.log(JSON.parse(JSON.stringify(witnesses)))
+            }
             // now work out from context if it should be lac or om
             for (let k = 0; k < witnesses.length; k += 1) {
               // if this witness is overlapped do not try to fix - it should be displayed as om regardless
@@ -1377,13 +1390,31 @@ var CL = (function() {
                 }
               }
             }
+            if (i === 2) {
+              console.log('}}}}}}}}}')
+              console.log(witnesses)
+              console.log(JSON.parse(JSON.stringify(apparatus[i])))
+            }
             apparatus[i].readings[j].witnesses = CL.removeNullItems(witnesses); //strip null from witnesses
+            if (i === 2) {
+              console.log('}}}}}}}}}')
+              console.log(JSON.parse(JSON.stringify(apparatus[i])))
+            }
             //if no witnesses remain delete the reading
             if (apparatus[i].readings[j].witnesses.length === 0) {
               apparatus[i].readings[j] = null;
             }
+            if (i === 2) {
+              console.log('}}}}}}}}}')
+              console.log(JSON.parse(JSON.stringify(apparatus[i])))
+            }
           }
         }
+        if (i === 2) {
+          console.log('££££££££££££')
+          console.log(JSON.parse(JSON.stringify(apparatus[i])))
+        }
+        
         apparatus[i].readings = CL.removeNullItems(apparatus[i].readings);
         for (let j = 0; j < extraReadings.length; j += 1) {
           CL.addReadingId(extraReadings[j], apparatus[i].start, apparatus[i].end);
@@ -1589,7 +1620,7 @@ var CL = (function() {
         i = 0;
       } else {
         i = 1;
-      }
+      }     
       for (i; i < unit.readings.length; i += 1) {
         witnesses.push.apply(witnesses, unit.readings[i].witnesses);
         if (Object.prototype.hasOwnProperty.call(unit.readings[i], 'subreadings')) {

--- a/static/CE_core/js/collation.js
+++ b/static/CE_core/js/collation.js
@@ -1594,7 +1594,7 @@ var CL = (function() {
         i = 0;
       } else {
         i = 1;
-      }     
+      }
       for (i; i < unit.readings.length; i += 1) {
         witnesses.push.apply(witnesses, unit.readings[i].witnesses);
         if (Object.prototype.hasOwnProperty.call(unit.readings[i], 'subreadings')) {

--- a/static/CE_core/js/collation.js
+++ b/static/CE_core/js/collation.js
@@ -202,7 +202,7 @@ var CL = (function() {
       const text = [];
       text.push(start);
       text.push(end);
-      for (let i = 0; i < unit.readings.length; i += 1) {      
+      for (let i = 0; i < unit.readings.length; i += 1) {
         text.push(CL.extractWitnessText(unit.readings[i]) + unit.readings[i].witnesses.join(' '));
       }
       if (typeof appId !== 'undefined') {

--- a/static/CE_core/js/collation.js
+++ b/static/CE_core/js/collation.js
@@ -202,7 +202,7 @@ var CL = (function() {
       const text = [];
       text.push(start);
       text.push(end);
-      for (let i = 0; i < unit.readings.length; i += 1) {        
+      for (let i = 0; i < unit.readings.length; i += 1) {      
         text.push(CL.extractWitnessText(unit.readings[i]) + unit.readings[i].witnesses.join(' '));
       }
       if (typeof appId !== 'undefined') {

--- a/static/CE_core/js/collation.js
+++ b/static/CE_core/js/collation.js
@@ -202,7 +202,7 @@ var CL = (function() {
       const text = [];
       text.push(start);
       text.push(end);
-      for (let i = 0; i < unit.readings.length; i += 1) {
+      for (let i = 0; i < unit.readings.length; i += 1) {        
         text.push(CL.extractWitnessText(unit.readings[i]) + unit.readings[i].witnesses.join(' '));
       }
       if (typeof appId !== 'undefined') {
@@ -1327,15 +1327,10 @@ var CL = (function() {
       // first strip all the empty units displaying gaps and then recreate the ones we still need
       CL._cleanExtraGaps();
       CL._createExtraGaps();
-      console.log('@@@@@@@@@@')
-      console.log(JSON.parse(JSON.stringify(CL.data)))
       const apparatus = CL.data.apparatus;
       for (let i = 0; i < apparatus.length; i += 1) { // loop through units
         extraReadings = [];
         for (let j = 0; j < apparatus[i].readings.length; j += 1) { // loop through readings
-          if (i === 2) {
-            console.log(JSON.parse(JSON.stringify(apparatus[i].readings[j])))
-          }
           // if this is reading contains an empty reading and if this isn't a whole verse lac or whole verse om
           if (CL._containsEmptyReading(apparatus[i].readings[j]) &&  // includes subreadings and SR_text
                     apparatus[i].readings[j].type !== 'lac_verse' &&
@@ -1346,16 +1341,8 @@ var CL = (function() {
             }
             // gets all witnesses that have an empty reading including those in subreadings
             emptyWitnesses = CL._getAllEmptyReadingWitnesses(apparatus[i].readings[j]);
-            if (i === 2) {
-              console.log('empty witnesses')
-              console.log(JSON.parse(JSON.stringify(emptyWitnesses)))
-            }
             // get all the witnesses for the reading
             witnesses = CL.getAllReadingWitnesses(apparatus[i].readings[j]);
-            if (i === 2) {
-              console.log('witnesses')
-              console.log(JSON.parse(JSON.stringify(witnesses)))
-            }
             // now work out from context if it should be lac or om
             for (let k = 0; k < witnesses.length; k += 1) {
               // if this witness is overlapped do not try to fix - it should be displayed as om regardless
@@ -1386,35 +1373,22 @@ var CL = (function() {
                                   apparatus[i].readings[j].SR_text[witnesses[k]].text.length === 0) {
                   // squelch if this is an om reading which is a subreading of another reading
                 } else {
-                  witnesses[k] = null;
+                  /**This used to be in place. I took it out because it was removing witnesses when combining units
+                   * which contained a reading with text regularised to lac when combining with an om. I am laving the
+                   * line here for now, commented out, because it might break something else and this will remind me
+                   * what I did (2/3/26).
+                   */
+                  // witnesses[k] = null;
                 }
               }
             }
-            if (i === 2) {
-              console.log('}}}}}}}}}')
-              console.log(witnesses)
-              console.log(JSON.parse(JSON.stringify(apparatus[i])))
-            }
             apparatus[i].readings[j].witnesses = CL.removeNullItems(witnesses); //strip null from witnesses
-            if (i === 2) {
-              console.log('}}}}}}}}}')
-              console.log(JSON.parse(JSON.stringify(apparatus[i])))
-            }
             //if no witnesses remain delete the reading
             if (apparatus[i].readings[j].witnesses.length === 0) {
               apparatus[i].readings[j] = null;
             }
-            if (i === 2) {
-              console.log('}}}}}}}}}')
-              console.log(JSON.parse(JSON.stringify(apparatus[i])))
-            }
           }
         }
-        if (i === 2) {
-          console.log('££££££££££££')
-          console.log(JSON.parse(JSON.stringify(apparatus[i])))
-        }
-        
         apparatus[i].readings = CL.removeNullItems(apparatus[i].readings);
         for (let j = 0; j < extraReadings.length; j += 1) {
           CL.addReadingId(extraReadings[j], apparatus[i].start, apparatus[i].end);

--- a/static/CE_core/js/collation.js
+++ b/static/CE_core/js/collation.js
@@ -1373,12 +1373,7 @@ var CL = (function() {
                                   apparatus[i].readings[j].SR_text[witnesses[k]].text.length === 0) {
                   // squelch if this is an om reading which is a subreading of another reading
                 } else {
-                  /** This used to be in place. I took it out because it was removing witnesses when combining units
-                   * which contained a reading with text regularised to lac when combining with an om. I am leaving the
-                   * line here for now, commented out, because it might break something else and this will remind me
-                   * what I did (2/3/26).
-                   */
-                  // witnesses[k] = null;
+                  witnesses[k] = null;
                 }
               }
             }

--- a/static/CE_core/js/collation.js
+++ b/static/CE_core/js/collation.js
@@ -1373,8 +1373,8 @@ var CL = (function() {
                                   apparatus[i].readings[j].SR_text[witnesses[k]].text.length === 0) {
                   // squelch if this is an om reading which is a subreading of another reading
                 } else {
-                  /**This used to be in place. I took it out because it was removing witnesses when combining units
-                   * which contained a reading with text regularised to lac when combining with an om. I am laving the
+                  /** This used to be in place. I took it out because it was removing witnesses when combining units
+                   * which contained a reading with text regularised to lac when combining with an om. I am leaving the
                    * line here for now, commented out, because it might break something else and this will remind me
                    * what I did (2/3/26).
                    */

--- a/static/CE_core/js/set_variants.js
+++ b/static/CE_core/js/set_variants.js
@@ -34,7 +34,7 @@ var SV = (function() {
      *              	error_unit - the unit which needs to be highlighted as an error*/
     showSetVariants: function(options) {
       var footerHtml, preselectedAddedHighlight;
-      console.log(CL.data);
+      console.log(JSON.parse(JSON.stringify(CL.data)));
       CL.stage = 'set';
       if (typeof options === 'undefined') {
         options = {};
@@ -5067,6 +5067,7 @@ var SV = (function() {
       SV.prepareForOperation();
       const scrollOffset = [document.getElementById('scroller').scrollLeft,
                             document.getElementById('scroller').scrollTop];
+
       // find the correct apparatus
       if (index.match(/-app-/g)) {
         apparatusNum = parseInt(index.match(/\d+/g)[1], 10);
@@ -5306,6 +5307,7 @@ var SV = (function() {
           if (postChunk.length > 0) {
             after = postChunk[0];
           }
+          
           const baseCollationChunk = {
             'structure': {
               'apparatus': chunk, 'lac_readings': originalData.lac_readings, 'om_readings': originalData.om_readings
@@ -5319,6 +5321,8 @@ var SV = (function() {
             data.apparatus[data.apparatus.length - 1].end + 1,
             [before, after]
           );
+          // mergedCollationChunk.structure.apparatus[1].first_word_index = '3.1';
+          // mergedCollationChunk.structure.apparatus[2].first_word_index = '3.2';
           CL.existingCollation.apparatus = preChunk.concat(mergedCollationChunk.structure.apparatus, postChunk);
           CL.data = JSON.parse(JSON.stringify(CL.existingCollation));
           CL.lacOmFix(); // call this again on the full collation

--- a/static/CE_core/js/set_variants.js
+++ b/static/CE_core/js/set_variants.js
@@ -254,9 +254,17 @@ var SV = (function() {
           }
         }
       }
+      console.log('&&&&&&&')
+      console.log(JSON.parse(JSON.stringify(CL.data)))
       SV.prepareForOperation();
+      console.log('{{{{{{{{{{{{{{{')
+      console.log(JSON.parse(JSON.stringify(CL.data)))
       CL.lacOmFix();  // also does extra gaps
+      console.log('%%%%%%%%%%%%')
+      console.log(JSON.parse(JSON.stringify(CL.data)))
       SV.unprepareForOperation();
+      console.log('************')
+      console.log(JSON.parse(JSON.stringify(CL.data)))
       temp = CL.getUnitLayout(CL.data.apparatus, 1, 'set_variants', options);
       header = CL.getCollationHeader(CL.data, temp[1], true);
       html = header[0];
@@ -1212,14 +1220,17 @@ var SV = (function() {
             newReadings[text] = newRdg;
             SV._addTypeAndDetails(newReadings[text], readings1[read1], readings2[read2]);
           }
+          
         }
       }
+      console.log(JSON.parse(JSON.stringify(newReadings)));
       newunit.readings = [];
       for (const key in newReadings) {
         if (Object.prototype.hasOwnProperty.call(newReadings, key)) {
           newunit.readings.push(SV._fixIndexNumbers(newReadings[key]));
         }
       }
+      console.log(JSON.parse(JSON.stringify(newunit)));
       return newunit;
     },
 
@@ -2617,6 +2628,9 @@ var SV = (function() {
           }
         }
         newunit = SV.combineReadings(unit1.readings, unit2.readings, newunit, false);
+        console.log('###########')
+        console.log(JSON.parse(JSON.stringify(newunit)))
+        console.log('###########')
         if (keepId === true) {
           newunit._id = unit1._id;
         } else {
@@ -2671,6 +2685,8 @@ var SV = (function() {
         } else {
           SV._checkAndFixIndexOrder(newunit.start);
         }
+        console.log('----------------')
+        console.log(JSON.parse(JSON.stringify(newunit)))
         // in here split out 'a' reading if we are dealing with overlapping units
         // and always separate is as a different reading even when other readings agree
         if (appId !== 'apparatus') {
@@ -2684,8 +2700,14 @@ var SV = (function() {
             }
           }
         }
+        console.log('============')
+        console.log(JSON.parse(JSON.stringify(newunit)))
         SV.unsplitUnitWitnesses(index, 'apparatus'); //just in case
+        console.log('+++++++++++')
+        console.log(JSON.parse(JSON.stringify(newunit)))
         SV.unprepareForOperation();
+        console.log('^^^^^^^^^^^^^')
+        console.log(JSON.parse(JSON.stringify(newunit)))
         if (appId !== 'apparatus') {
           // then check that all witness words in the unit are only 2 apart
           problems = SV._checkUnitIntegrity(appId, index);
@@ -2704,6 +2726,8 @@ var SV = (function() {
             'error_unit': warningUnit
           });
         } else {
+          console.log('$$$$$$$$$$$$$$$$$$')
+          console.log(JSON.parse(JSON.stringify(CL.data)))
           SV.showSetVariantsData({});
         }
       } else {
@@ -2715,6 +2739,7 @@ var SV = (function() {
         } else if (overlapStatusAgreement === false) {
           errorMess = 'ERROR: These units cannot be combined as some of the witnesses have different statuses (deleted, overlapped etc.)';
         }
+        console.log(errorMess)
         SV.unprepareForOperation();
         SV.showSetVariantsData({
           'message': {
@@ -3411,6 +3436,10 @@ var SV = (function() {
           delete currentText[i].combined_gap_after;
         }
       }
+      if (witness === '256C') {
+        console.log(currentText)
+      }
+      
       return currentText;
     },
 
@@ -4499,6 +4528,8 @@ var SV = (function() {
       // because the rest of the function works on the basis they are there
       SR.loseSubreadings();
       SR.findSubreadings();
+      console.log('~~~~~~~~~~~~~~~~')
+      console.log(JSON.parse(JSON.stringify(CL.data)))
       const data = CL.data;
       for (const key in data) {
         if (Object.prototype.hasOwnProperty.call(data, key)) {

--- a/static/CE_core/js/set_variants.js
+++ b/static/CE_core/js/set_variants.js
@@ -1181,12 +1181,6 @@ var SV = (function() {
                                                         [read1, read2], witness,
                                                         newReadings[text].text).sort(SV._compareIndexes);
           } else {
-            console.log('-----------')
-            console.log(text)
-            console.log(JSON.parse(JSON.stringify(readings1)))
-            console.log(JSON.parse(JSON.stringify(read1)))
-            console.log(witness)
-            console.log('-----------')
             newRdg = {
               'witnesses': [witness],
               'text': SV._combineReadingText(readings1, readings2, [read1, read2], witness, [])
@@ -1221,7 +1215,6 @@ var SV = (function() {
           
         }
       }
-      console.log(JSON.parse(JSON.stringify(newReadings)))
       newunit.readings = [];
       for (const key in newReadings) {
         if (Object.prototype.hasOwnProperty.call(newReadings, key)) {
@@ -2555,7 +2548,7 @@ var SV = (function() {
       return a;
     },
 
-    _doCombineUnits: function(units, appId, keepId) {
+    _doCombineUnits: function(units, appId, keepId, redraw) {
       let newunit, index, warningMess, errorMess, problems, warningUnit, combinedGapBeforeSubreadings,
           combinedGapAfterSubreadings, combinedGapBeforeSubreadingsDetails;
   
@@ -2567,7 +2560,9 @@ var SV = (function() {
       const witnessEquality = SV._checkWitnessEquality(unit1, unit2, appId);
       const overlapBoundaries = SV._checkOverlapBoundaries(unit1, unit2, appId);
       const overlapStatusAgreement = SV._checkOverlapStatusAgreement(unit1, unit2, appId);
-      SV._addToUndoStack(CL.data);
+      if (redraw !== false) {
+        SV._addToUndoStack(CL.data);
+      }
       if (witnessEquality && overlapBoundaries && overlapStatusAgreement) {
         if (keepId === true) {
           // combine the reference ids in the top apparatus
@@ -2702,6 +2697,9 @@ var SV = (function() {
             warningUnit = [appId, index];
           }
         }
+        if (redraw === false) {
+          return;
+        }
         SV.checkBugStatus('combine', appId + ' unit ' + Math.min(units[0][0], units[1][0]) + ' with unit ' + Math.max(units[0][0], units[1][0]) + '.');
         if (warningMess !== undefined) {
           SV.showSetVariantsData({
@@ -2723,8 +2721,10 @@ var SV = (function() {
         } else if (overlapStatusAgreement === false) {
           errorMess = 'ERROR: These units cannot be combined as some of the witnesses have different statuses (deleted, overlapped etc.)';
         }
-        console.log(errorMess)
         SV.unprepareForOperation();
+        if (redraw === false) {
+          return;
+        }
         SV.showSetVariantsData({
           'message': {
             'type': 'error',
@@ -3001,11 +3001,7 @@ var SV = (function() {
       let unit1, unit2, errorMess;
       const scrollOffset = [document.getElementById('scroller').scrollLeft,
                             document.getElementById('scroller').scrollTop];
-      console.log('############ - pre-prepared')
-      console.log(JSON.parse(JSON.stringify(CL.data)))
       SV.prepareForOperation();
-      console.log(JSON.parse(JSON.stringify(CL.data)))
-      console.log('############ - prepared')
       // at this point both units are from same apparatus
       const appId = units[0][1];
       if (appId === 'apparatus') {
@@ -5137,6 +5133,29 @@ var SV = (function() {
           return;
         }
       }
+      /** Now, if the overlaps contain text, check the odd numbered units either side of the extent we are going to be
+       * removing. If there is more than one unit already at that index point then the user must reduce that to one
+       * before removing another overlap containing text. This is to ensure that any units added can be numbered uniquely
+       * and in order (using .0 where for the odd unit after the overlap). Overlaps without text are fine because we
+       * know they will never add any more units into the odd numbered index points.
+       */
+      if (SV._containsText([overlapUnit]) || SV._containsText(candidateOverlaps)) {
+        let startWord = CL.data.apparatus[range[0]].start;
+        let endWord = CL.data.apparatus[range[1]].end;
+        if (startWord % 2 == 0) {
+          startWord = startWord - 1;
+        }
+        if (endWord % 2 == 0) {
+          endWord = endWord + 1;
+        }
+        if (SV._adjacentIndexPointsHaveMultipleUnits(range)) {
+          alert('This overlap cannot be removed while there are mutliple units at word index ' +
+                startWord + ' and/or ' + endWord + '.\n' +
+                'Please reduce the units at these word index to one and then try again.');
+          spinner.removeLoadingOverlay();
+          return;
+        }
+      }
       /** remove the relevant witnesses from the section of the collation representing the overlap while also removing
        * any standoff regularisations for these witnesses in the units being removed in the top line (we only need to do
        * this for the top line because overlaps will be removed entirely and the standoff removed as part of the clean
@@ -5281,6 +5300,33 @@ var SV = (function() {
           }
           CL.lacOmFix();
           // copy so we can change CL.data without screwing this up
+          // merge any units that would end up as additions before and after the chunk being combined
+          // NB: CL.data and data are the same thing at this point
+          while (data.apparatus[0].start === 1 && data.apparatus[1].start === 1) {
+            SV._doCombineUnits([[0, 'apparatus'], [1, 'apparatus']], 'apparatus', undefined, false);
+          }
+          // one final combine to get it all in an even unit if possible
+          if (data.apparatus[0].start === 1 && data.apparatus.length > 1) {
+            SV._doCombineUnits([[0, 'apparatus'], [1, 'apparatus']], 'apparatus', undefined, false);
+          } 
+          while (data.apparatus[data.apparatus.length - 1].start % 2 === 1 &&
+                  data.apparatus[data.apparatus.length - 2].start % 2 === 1) {
+            SV._doCombineUnits(
+              [[data.apparatus.length - 2, 'apparatus'], [data.apparatus.length - 1, 'apparatus']],
+              'apparatus',
+              undefined,
+              false
+            );
+          }
+          // one final combine to get it all in an even unit if possible
+          if (data.apparatus.length > 1 && data.apparatus[data.apparatus.length - 1].start % 2 === 1) {
+            SV._doCombineUnits(
+              [[data.apparatus.length - 2, 'apparatus'], [data.apparatus.length - 1, 'apparatus']],
+              'apparatus',
+              undefined,
+              false
+            );
+          }
           data = JSON.parse(JSON.stringify(CL.data));
           const originalApparatus = JSON.parse(JSON.stringify(CL.existingCollation.apparatus));
           const preChunk = originalApparatus.slice(0, range[0]);
@@ -5288,30 +5334,31 @@ var SV = (function() {
           // add the data back in
           // just get the chunk we need to change
           const chunk = CL.existingCollation.apparatus.slice(range[0], range[1] + 1);
-          // renumber units that start with 1 to the gap before the first non-gap unit
-          if (data.apparatus[0].start === 1 && preChunk.length > 0) {
-            let i = 0;
-            while(data.apparatus[i].start === 1) {
-              if (preChunk[preChunk.length -1].end % 2 === 0) { // this is an even numbered unit 
-                data.apparatus[i].start = preChunk[preChunk.length -1].end + 1;
-                data.apparatus[i].end = preChunk[preChunk.length -1].end + 1;
-                if (i === 0) {
-                  data.apparatus[i].first_word_index = data.apparatus[i].end + '.1';
-                } else {
-                  data.apparatus[i].first_word_index = SV._incrementSubIndex(data.apparatus[i - 1].first_word_index, 1);
-                }
-              } else { // this is an addition unit
-                data.apparatus[i].start = preChunk[preChunk.length -1].end;
-                data.apparatus[i].end = preChunk[preChunk.length -1].end;
-                if (i === 0) {
-                  data.apparatus[i].first_word_index = SV._incrementSubIndex(preChunk[preChunk.length -1].first_word_index, 1);
-                } else {
-                  data.apparatus[i].first_word_index = SV._incrementSubIndex(data.apparatus[i - 1].first_word_index, 1);
-                }
-              }
-              i += 1;
-            }
-          }
+          // check and renumber and units in the odd spaces either side of the chunk we recollated
+          // if (preChunk.length > 0 && data.apparatus[0].start === 1) {
+          //   if (preChunk[preChunk.length - 1].end > 1) {
+          //     if (preChunk[preChunk.length - 1].end % 2 === 0) {
+          //       data.apparatus[0].start = preChunk[preChunk.length - 1].end + 1;
+          //       data.apparatus[0].end = preChunk[preChunk.length - 1].end + 1;
+          //       data.apparatus[0].first_word_index = data.apparatus[0].end + '.1';
+          //     } else {
+          //       data.apparatus[0].start = preChunk[preChunk.length - 1].end;
+          //       data.apparatus[0].end = preChunk[preChunk.length - 1].end;
+          //       data.apparatus[0].first_word_index = SV._incrementSubIndex(preChunk[preChunk.length - 1].first_word_index, 1);
+          //     } 
+          //   }
+          //   const mainIndexPoint = data.apparatus[0].end;
+          //   for (let reading of data.apparatus[0].readings) {
+          //     if (reading.text.length > 0) {
+          //       for (let word of reading.text) {
+          //         word.index = mainIndexPoint + '.0';
+          //       }
+          //     }
+          //   }
+          // }
+          // if (postChunk.length > 0 && postChunk[0].start % 2 === 1 && postChunk[0].start === data.apparatus[data.apparatus.length - 1].start) {
+          //   data.apparatus[data.apparatus.length - 1].first_word_index = data.apparatus[data.apparatus.length - 1].start + '.0';
+          // }
           before = null;
           after = null;
           if (preChunk.length > 0) {
@@ -5334,8 +5381,7 @@ var SV = (function() {
             data.apparatus[data.apparatus.length - 1].end + 1,
             [before, after]
           );
-          // mergedCollationChunk.structure.apparatus[1].first_word_index = '3.1';
-          // mergedCollationChunk.structure.apparatus[2].first_word_index = '3.2';
+
           CL.existingCollation.apparatus = preChunk.concat(mergedCollationChunk.structure.apparatus, postChunk);
           CL.data = JSON.parse(JSON.stringify(CL.existingCollation));
           CL.lacOmFix(); // call this again on the full collation
@@ -5355,6 +5401,52 @@ var SV = (function() {
           document.getElementById('scroller').scrollTop = scrollOffset[1];
         });
       });
+    },
+
+    _containsText: function(unitList) {
+      /* Check if any of the provided units contain any text (either in main or subreadings) */
+      for (let unit of unitList) {
+        for (let i = 1; i < unit.readings.length; i += 1) {
+          if (unit.readings[i].text.length > 0) {
+            return true;
+          }
+          if (unit.readings[i].SR_text) {
+            for (let key in unit.readings[i].SR_text) {
+              if (unit.readings[i].SR_text[key].text.length > 0) {
+                return true;
+              }
+            }
+          }
+        }
+      }
+      return false;
+    },
+
+    _adjacentIndexPointsHaveMultipleUnits: function(range) {
+      let start, end;
+      if (CL.data.apparatus[range[0]].start % 2 == 0) {
+        start = CL.data.apparatus[range[0]].start - 1;
+      } else {
+        start = CL.data.apparatus[range[0]].start;
+      }
+      if (CL.data.apparatus[range[1]].end % 2 == 0) {
+        end = CL.data.apparatus[range[1]].end + 1;
+      } else {
+        end = CL.data.apparatus[range[1]].end;
+      }
+      let startUnits = 0, endUnits = 0;
+      for (let unit of CL.data.apparatus) {
+        if (unit.start == start) {
+          startUnits += 1;
+        }
+        if (unit.end == end) {
+          endUnits += 1;
+        }
+      }
+      if (startUnits > 1 || endUnits > 1) {
+        return true;
+      }
+      return false;
     },
 
     _getAppIdAndIndexByOverlapId: function(unitId) {

--- a/static/CE_core/js/set_variants.js
+++ b/static/CE_core/js/set_variants.js
@@ -5133,29 +5133,6 @@ var SV = (function() {
           return;
         }
       }
-      /** Now, if the overlaps contain text, check the odd numbered units either side of the extent we are going to be
-       * removing. If there is more than one unit already at that index point then the user must reduce that to one
-       * before removing another overlap containing text. This is to ensure that any units added can be numbered uniquely
-       * and in order (using .0 where for the odd unit after the overlap). Overlaps without text are fine because we
-       * know they will never add any more units into the odd numbered index points.
-       */
-      if (SV._containsText([overlapUnit]) || SV._containsText(candidateOverlaps)) {
-        let startWord = CL.data.apparatus[range[0]].start;
-        let endWord = CL.data.apparatus[range[1]].end;
-        if (startWord % 2 == 0) {
-          startWord = startWord - 1;
-        }
-        if (endWord % 2 == 0) {
-          endWord = endWord + 1;
-        }
-        if (SV._adjacentIndexPointsHaveMultipleUnits(range)) {
-          alert('This overlap cannot be removed while there are mutliple units at word index ' +
-                startWord + ' and/or ' + endWord + '.\n' +
-                'Please reduce the units at these word index to one and then try again.');
-          spinner.removeLoadingOverlay();
-          return;
-        }
-      }
       /** remove the relevant witnesses from the section of the collation representing the overlap while also removing
        * any standoff regularisations for these witnesses in the units being removed in the top line (we only need to do
        * this for the top line because overlaps will be removed entirely and the standoff removed as part of the clean
@@ -5299,16 +5276,39 @@ var SV = (function() {
             }
           }
           CL.lacOmFix();
-          // copy so we can change CL.data without screwing this up
+
+          const originalApparatus = JSON.parse(JSON.stringify(CL.existingCollation.apparatus));
+          const preChunk = originalApparatus.slice(0, range[0]);
+          const postChunk = originalApparatus.slice(range[1]+ 1);
+          // just get the chunk we need to change
+          const chunk = CL.existingCollation.apparatus.slice(range[0], range[1] + 1);
+          // Check and renumber units in the odd space before the chunk if required (if they have been assigned 1 and
+          // the overlap being removed didn't start at 1 or 2)
+          let i = 0; 
+          if (preChunk.length > 0) {
+            while(data.apparatus[i].start === 1) {
+              if (preChunk[preChunk.length - 1].end > 1) {
+                if (preChunk[preChunk.length - 1].end % 2 === 0) {
+                  data.apparatus[i].start = preChunk[preChunk.length - 1].end + 1;
+                  data.apparatus[i].end = preChunk[preChunk.length - 1].end + 1;
+                  data.apparatus[i].first_word_index = data.apparatus[0].end + '.1';
+                } else {
+                  data.apparatus[i].start = preChunk[preChunk.length - 1].end;
+                  data.apparatus[i].end = preChunk[preChunk.length - 1].end;
+                  data.apparatus[i].first_word_index = SV._incrementSubIndex(preChunk[preChunk.length - 1].first_word_index, 1);
+                } 
+              }
+              i += 1;
+            }
+          }
           // merge any units that would end up as additions before and after the chunk being combined
-          // NB: CL.data and data are the same thing at this point
-          while (data.apparatus[0].start === 1 && data.apparatus[1].start === 1) {
+          while (data.apparatus[0].start % 2 === 1 && data.apparatus[1].start % 2 === 1) {
             SV._doCombineUnits([[0, 'apparatus'], [1, 'apparatus']], 'apparatus', undefined, false);
           }
-          // one final combine to get it all in an even unit if possible
-          if (data.apparatus[0].start === 1 && data.apparatus.length > 1) {
+          // one final combine to get it all in an even unit if possible and necessary
+          if (data.apparatus[0].start % 2 === 1 && data.apparatus.length > 1 && chunk[0].end % 2 !== 1) {
             SV._doCombineUnits([[0, 'apparatus'], [1, 'apparatus']], 'apparatus', undefined, false);
-          } 
+          }
           while (data.apparatus[data.apparatus.length - 1].start % 2 === 1 &&
                   data.apparatus[data.apparatus.length - 2].start % 2 === 1) {
             SV._doCombineUnits(
@@ -5318,8 +5318,8 @@ var SV = (function() {
               false
             );
           }
-          // one final combine to get it all in an even unit if possible
-          if (data.apparatus.length > 1 && data.apparatus[data.apparatus.length - 1].start % 2 === 1) {
+          // one final combine to get it all in an even unit if possible and necessary
+          if (data.apparatus.length > 1 && data.apparatus[data.apparatus.length - 1].start % 2 === 1 && chunk[chunk.length - 1].end % 2 !== 1) {
             SV._doCombineUnits(
               [[data.apparatus.length - 2, 'apparatus'], [data.apparatus.length - 1, 'apparatus']],
               'apparatus',
@@ -5327,38 +5327,8 @@ var SV = (function() {
               false
             );
           }
-          data = JSON.parse(JSON.stringify(CL.data));
-          const originalApparatus = JSON.parse(JSON.stringify(CL.existingCollation.apparatus));
-          const preChunk = originalApparatus.slice(0, range[0]);
-          const postChunk = originalApparatus.slice(range[1]+ 1);
-          // add the data back in
-          // just get the chunk we need to change
-          const chunk = CL.existingCollation.apparatus.slice(range[0], range[1] + 1);
-          // check and renumber and units in the odd spaces either side of the chunk we recollated
-          // if (preChunk.length > 0 && data.apparatus[0].start === 1) {
-          //   if (preChunk[preChunk.length - 1].end > 1) {
-          //     if (preChunk[preChunk.length - 1].end % 2 === 0) {
-          //       data.apparatus[0].start = preChunk[preChunk.length - 1].end + 1;
-          //       data.apparatus[0].end = preChunk[preChunk.length - 1].end + 1;
-          //       data.apparatus[0].first_word_index = data.apparatus[0].end + '.1';
-          //     } else {
-          //       data.apparatus[0].start = preChunk[preChunk.length - 1].end;
-          //       data.apparatus[0].end = preChunk[preChunk.length - 1].end;
-          //       data.apparatus[0].first_word_index = SV._incrementSubIndex(preChunk[preChunk.length - 1].first_word_index, 1);
-          //     } 
-          //   }
-          //   const mainIndexPoint = data.apparatus[0].end;
-          //   for (let reading of data.apparatus[0].readings) {
-          //     if (reading.text.length > 0) {
-          //       for (let word of reading.text) {
-          //         word.index = mainIndexPoint + '.0';
-          //       }
-          //     }
-          //   }
-          // }
-          // if (postChunk.length > 0 && postChunk[0].start % 2 === 1 && postChunk[0].start === data.apparatus[data.apparatus.length - 1].start) {
-          //   data.apparatus[data.apparatus.length - 1].first_word_index = data.apparatus[data.apparatus.length - 1].start + '.0';
-          // }
+          data = JSON.parse(JSON.stringify(CL.data));   
+          // add the data back in         
           before = null;
           after = null;
           if (preChunk.length > 0) {
@@ -5401,52 +5371,6 @@ var SV = (function() {
           document.getElementById('scroller').scrollTop = scrollOffset[1];
         });
       });
-    },
-
-    _containsText: function(unitList) {
-      /* Check if any of the provided units contain any text (either in main or subreadings) */
-      for (let unit of unitList) {
-        for (let i = 1; i < unit.readings.length; i += 1) {
-          if (unit.readings[i].text.length > 0) {
-            return true;
-          }
-          if (unit.readings[i].SR_text) {
-            for (let key in unit.readings[i].SR_text) {
-              if (unit.readings[i].SR_text[key].text.length > 0) {
-                return true;
-              }
-            }
-          }
-        }
-      }
-      return false;
-    },
-
-    _adjacentIndexPointsHaveMultipleUnits: function(range) {
-      let start, end;
-      if (CL.data.apparatus[range[0]].start % 2 == 0) {
-        start = CL.data.apparatus[range[0]].start - 1;
-      } else {
-        start = CL.data.apparatus[range[0]].start;
-      }
-      if (CL.data.apparatus[range[1]].end % 2 == 0) {
-        end = CL.data.apparatus[range[1]].end + 1;
-      } else {
-        end = CL.data.apparatus[range[1]].end;
-      }
-      let startUnits = 0, endUnits = 0;
-      for (let unit of CL.data.apparatus) {
-        if (unit.start == start) {
-          startUnits += 1;
-        }
-        if (unit.end == end) {
-          endUnits += 1;
-        }
-      }
-      if (startUnits > 1 || endUnits > 1) {
-        return true;
-      }
-      return false;
     },
 
     _getAppIdAndIndexByOverlapId: function(unitId) {

--- a/static/CE_core/js/set_variants.js
+++ b/static/CE_core/js/set_variants.js
@@ -34,7 +34,7 @@ var SV = (function() {
      *              	error_unit - the unit which needs to be highlighted as an error*/
     showSetVariants: function(options) {
       var footerHtml, preselectedAddedHighlight;
-      console.log(JSON.parse(JSON.stringify(CL.data)));
+      console.log(CL.data);
       CL.stage = 'set';
       if (typeof options === 'undefined') {
         options = {};
@@ -1212,7 +1212,6 @@ var SV = (function() {
             newReadings[text] = newRdg;
             SV._addTypeAndDetails(newReadings[text], readings1[read1], readings2[read2]);
           }
-          
         }
       }
       newunit.readings = [];

--- a/static/CE_core/js/set_variants.js
+++ b/static/CE_core/js/set_variants.js
@@ -1182,6 +1182,7 @@ var SV = (function() {
                                                         newReadings[text].text).sort(SV._compareIndexes);
           } else {
             console.log('-----------')
+            console.log(text)
             console.log(JSON.parse(JSON.stringify(readings1)))
             console.log(JSON.parse(JSON.stringify(read1)))
             console.log(witness)
@@ -3000,7 +3001,11 @@ var SV = (function() {
       let unit1, unit2, errorMess;
       const scrollOffset = [document.getElementById('scroller').scrollLeft,
                             document.getElementById('scroller').scrollTop];
+      console.log('############ - pre-prepared')
+      console.log(JSON.parse(JSON.stringify(CL.data)))
       SV.prepareForOperation();
+      console.log(JSON.parse(JSON.stringify(CL.data)))
+      console.log('############ - prepared')
       // at this point both units are from same apparatus
       const appId = units[0][1];
       if (appId === 'apparatus') {

--- a/static/CE_core/js/set_variants.js
+++ b/static/CE_core/js/set_variants.js
@@ -3418,7 +3418,7 @@ var SV = (function() {
         if (Object.prototype.hasOwnProperty.call(currentText[i], 'combined_gap_after')) {
           delete currentText[i].combined_gap_after;
         }
-      }      
+      }
       return currentText;
     },
 
@@ -5075,7 +5075,6 @@ var SV = (function() {
       SV.prepareForOperation();
       const scrollOffset = [document.getElementById('scroller').scrollLeft,
                             document.getElementById('scroller').scrollTop];
-
       // find the correct apparatus
       if (index.match(/-app-/g)) {
         apparatusNum = parseInt(index.match(/\d+/g)[1], 10);
@@ -5336,7 +5335,6 @@ var SV = (function() {
           if (postChunk.length > 0) {
             after = postChunk[0];
           }
-          
           const baseCollationChunk = {
             'structure': {
               'apparatus': chunk, 'lac_readings': originalData.lac_readings, 'om_readings': originalData.om_readings
@@ -5350,7 +5348,6 @@ var SV = (function() {
             data.apparatus[data.apparatus.length - 1].end + 1,
             [before, after]
           );
-
           CL.existingCollation.apparatus = preChunk.concat(mergedCollationChunk.structure.apparatus, postChunk);
           CL.data = JSON.parse(JSON.stringify(CL.existingCollation));
           CL.lacOmFix(); // call this again on the full collation

--- a/static/CE_core/js/set_variants.js
+++ b/static/CE_core/js/set_variants.js
@@ -2550,7 +2550,9 @@ var SV = (function() {
     _doCombineUnits: function(units, appId, keepId, redraw) {
       let newunit, index, warningMess, errorMess, problems, warningUnit, combinedGapBeforeSubreadings,
           combinedGapAfterSubreadings, combinedGapBeforeSubreadingsDetails;
-  
+      if (redraw === undefined) {
+        redraw = true;
+      }
       const scrollOffset = [document.getElementById('scroller').scrollLeft,
                             document.getElementById('scroller').scrollTop];
       // make sure unit 1 is leftmost and unit 2 is rightmost
@@ -2559,7 +2561,7 @@ var SV = (function() {
       const witnessEquality = SV._checkWitnessEquality(unit1, unit2, appId);
       const overlapBoundaries = SV._checkOverlapBoundaries(unit1, unit2, appId);
       const overlapStatusAgreement = SV._checkOverlapStatusAgreement(unit1, unit2, appId);
-      if (redraw !== false) {
+      if (redraw === true) {
         SV._addToUndoStack(CL.data);
       }
       if (witnessEquality && overlapBoundaries && overlapStatusAgreement) {

--- a/static/CE_core/js/set_variants.js
+++ b/static/CE_core/js/set_variants.js
@@ -254,17 +254,9 @@ var SV = (function() {
           }
         }
       }
-      console.log('&&&&&&&')
-      console.log(JSON.parse(JSON.stringify(CL.data)))
       SV.prepareForOperation();
-      console.log('{{{{{{{{{{{{{{{')
-      console.log(JSON.parse(JSON.stringify(CL.data)))
       CL.lacOmFix();  // also does extra gaps
-      console.log('%%%%%%%%%%%%')
-      console.log(JSON.parse(JSON.stringify(CL.data)))
       SV.unprepareForOperation();
-      console.log('************')
-      console.log(JSON.parse(JSON.stringify(CL.data)))
       temp = CL.getUnitLayout(CL.data.apparatus, 1, 'set_variants', options);
       header = CL.getCollationHeader(CL.data, temp[1], true);
       html = header[0];
@@ -1189,6 +1181,11 @@ var SV = (function() {
                                                         [read1, read2], witness,
                                                         newReadings[text].text).sort(SV._compareIndexes);
           } else {
+            console.log('-----------')
+            console.log(JSON.parse(JSON.stringify(readings1)))
+            console.log(JSON.parse(JSON.stringify(read1)))
+            console.log(witness)
+            console.log('-----------')
             newRdg = {
               'witnesses': [witness],
               'text': SV._combineReadingText(readings1, readings2, [read1, read2], witness, [])
@@ -1223,14 +1220,13 @@ var SV = (function() {
           
         }
       }
-      console.log(JSON.parse(JSON.stringify(newReadings)));
+      console.log(JSON.parse(JSON.stringify(newReadings)))
       newunit.readings = [];
       for (const key in newReadings) {
         if (Object.prototype.hasOwnProperty.call(newReadings, key)) {
           newunit.readings.push(SV._fixIndexNumbers(newReadings[key]));
         }
       }
-      console.log(JSON.parse(JSON.stringify(newunit)));
       return newunit;
     },
 
@@ -2628,9 +2624,6 @@ var SV = (function() {
           }
         }
         newunit = SV.combineReadings(unit1.readings, unit2.readings, newunit, false);
-        console.log('###########')
-        console.log(JSON.parse(JSON.stringify(newunit)))
-        console.log('###########')
         if (keepId === true) {
           newunit._id = unit1._id;
         } else {
@@ -2685,8 +2678,6 @@ var SV = (function() {
         } else {
           SV._checkAndFixIndexOrder(newunit.start);
         }
-        console.log('----------------')
-        console.log(JSON.parse(JSON.stringify(newunit)))
         // in here split out 'a' reading if we are dealing with overlapping units
         // and always separate is as a different reading even when other readings agree
         if (appId !== 'apparatus') {
@@ -2700,14 +2691,8 @@ var SV = (function() {
             }
           }
         }
-        console.log('============')
-        console.log(JSON.parse(JSON.stringify(newunit)))
         SV.unsplitUnitWitnesses(index, 'apparatus'); //just in case
-        console.log('+++++++++++')
-        console.log(JSON.parse(JSON.stringify(newunit)))
         SV.unprepareForOperation();
-        console.log('^^^^^^^^^^^^^')
-        console.log(JSON.parse(JSON.stringify(newunit)))
         if (appId !== 'apparatus') {
           // then check that all witness words in the unit are only 2 apart
           problems = SV._checkUnitIntegrity(appId, index);
@@ -2726,8 +2711,6 @@ var SV = (function() {
             'error_unit': warningUnit
           });
         } else {
-          console.log('$$$$$$$$$$$$$$$$$$')
-          console.log(JSON.parse(JSON.stringify(CL.data)))
           SV.showSetVariantsData({});
         }
       } else {
@@ -3435,11 +3418,7 @@ var SV = (function() {
         if (Object.prototype.hasOwnProperty.call(currentText[i], 'combined_gap_after')) {
           delete currentText[i].combined_gap_after;
         }
-      }
-      if (witness === '256C') {
-        console.log(currentText)
-      }
-      
+      }      
       return currentText;
     },
 
@@ -4528,8 +4507,6 @@ var SV = (function() {
       // because the rest of the function works on the basis they are there
       SR.loseSubreadings();
       SR.findSubreadings();
-      console.log('~~~~~~~~~~~~~~~~')
-      console.log(JSON.parse(JSON.stringify(CL.data)))
       const data = CL.data;
       for (const key in data) {
         if (Object.prototype.hasOwnProperty.call(data, key)) {

--- a/static/CE_core/js/subreadings.js
+++ b/static/CE_core/js/subreadings.js
@@ -50,69 +50,72 @@ var SR = (function () {
                     if (markedReading.apparatus === key) { //if in right apparatus row
                       if (markedReading.start === apparatus[i].start &&
                         markedReading.end === apparatus[i].end) { //if unit extent is correct
-                        // find the child reading
-                        [child, childPos] = SR._findChildReading(apparatus[i], markedReading, _test);
-                        if (_test) {
-                          console.log('child is...');
-                          console.log(child);
-                        }
-                        // get the parent
-                        parent = SR._findParentReading(apparatus[i], key, markedReading, true, childPos);
-                        if (_test) {
-                          console.log('parent is...');
-                          console.log(parent);
-                        }
-                        if (parent !== null) {
-                          if (Object.prototype.hasOwnProperty.call(parent, 'subreadings')) {
-                            subreadings = parent.subreadings;
-                          } else {
-                            subreadings = {};
+                          if (!Object.prototype.hasOwnProperty.call(markedReading, 'first_word_index') ||
+                               markedReading.first_word_index === apparatus[i].first_word_index) { // check position
+                          // find the child reading
+                          [child, childPos] = SR._findChildReading(apparatus[i], markedReading, _test);
+                          if (_test) {
+                            console.log('child is...');
+                            console.log(child);
                           }
-                          if (child !== null) {
-                            markedReading.applied = true;
-                            SR._addCombinedGapDataToParent(parent, markedReading);
-                            // sort out the options
-                            options = {
-                              'standoff': true
-                            };
-                            if (typeof ruleClasses !== 'undefined') {
-                              options.rules = ruleClasses;
+                          // get the parent
+                          parent = SR._findParentReading(apparatus[i], key, markedReading, true, childPos);
+                          if (_test) {
+                            console.log('parent is...');
+                            console.log(parent);
+                          }
+                          if (parent !== null) {
+                            if (Object.prototype.hasOwnProperty.call(parent, 'subreadings')) {
+                              subreadings = parent.subreadings;
+                            } else {
+                              subreadings = {};
                             }
-                            if (typeof markedReading.reading_text !== 'undefined') {
-                              options.text = markedReading.reading_text;
-                              options.text = SR._getCorrectStandoffReadingText(markedReading, ruleClasses);
-                            }
-                            if (typeof markedReading.combined_gap_before !== 'undefined') {
-                              options.combined_gap_before = markedReading.combined_gap_before;
-                            }
-                            if (typeof markedReading.combined_gap_after !== 'undefined') {
-                              options.combined_gap_after = markedReading.combined_gap_after;
-                            }
-                            if (typeof markedReading.combined_gap_before_details !== 'undefined') {
-                              options.combined_gap_before_details = markedReading.combined_gap_before_details;
-                            }
-                            if (Object.prototype.hasOwnProperty.call(child, 'parents')) {
-                              parent.parents = child.parents;
-                            }
-                            if (_test) {
-                              console.log(options);
-                              console.log(JSON.parse(JSON.stringify(subreadings)));
-                            }
-                            // then make the subreading for that witness (you might have to split a reading)
-                            subreadings = SR._addToSubreadings(subreadings, child, markedReading.witness,
-                                                               markedReading.value.split('|'), options);
-                            if (SR._witnessIn(subreadings, markedReading.witness)) {
-                              parent.subreadings = subreadings;
-                              forDeletion.push([markedReading.witness, child]);
-                            }
-                            // for each reading we need to record the witnesses that were made subreading by standoff
-                            // readings rather than regularised readings. This is so we can put all standoff
-                            // subreadings in SR_text when we lose them (makes extracting text easier)
-                            if (!Object.prototype.hasOwnProperty.call(parent, 'standoff_subreadings')) {
-                              parent.standoff_subreadings = [];
-                            }
-                            if (parent.standoff_subreadings.indexOf(markedReading.witness) === -1) {
-                              parent.standoff_subreadings.push(markedReading.witness);
+                            if (child !== null) {
+                              markedReading.applied = true;
+                              SR._addCombinedGapDataToParent(parent, markedReading);
+                              // sort out the options
+                              options = {
+                                'standoff': true
+                              };
+                              if (typeof ruleClasses !== 'undefined') {
+                                options.rules = ruleClasses;
+                              }
+                              if (typeof markedReading.reading_text !== 'undefined') {
+                                options.text = markedReading.reading_text;
+                                options.text = SR._getCorrectStandoffReadingText(markedReading, ruleClasses);
+                              }
+                              if (typeof markedReading.combined_gap_before !== 'undefined') {
+                                options.combined_gap_before = markedReading.combined_gap_before;
+                              }
+                              if (typeof markedReading.combined_gap_after !== 'undefined') {
+                                options.combined_gap_after = markedReading.combined_gap_after;
+                              }
+                              if (typeof markedReading.combined_gap_before_details !== 'undefined') {
+                                options.combined_gap_before_details = markedReading.combined_gap_before_details;
+                              }
+                              if (Object.prototype.hasOwnProperty.call(child, 'parents')) {
+                                parent.parents = child.parents;
+                              }
+                              if (_test) {
+                                console.log(options);
+                                console.log(JSON.parse(JSON.stringify(subreadings)));
+                              }
+                              // then make the subreading for that witness (you might have to split a reading)
+                              subreadings = SR._addToSubreadings(subreadings, child, markedReading.witness,
+                                                                markedReading.value.split('|'), options);
+                              if (SR._witnessIn(subreadings, markedReading.witness)) {
+                                parent.subreadings = subreadings;
+                                forDeletion.push([markedReading.witness, child]);
+                              }
+                              // for each reading we need to record the witnesses that were made subreading by standoff
+                              // readings rather than regularised readings. This is so we can put all standoff
+                              // subreadings in SR_text when we lose them (makes extracting text easier)
+                              if (!Object.prototype.hasOwnProperty.call(parent, 'standoff_subreadings')) {
+                                parent.standoff_subreadings = [];
+                              }
+                              if (parent.standoff_subreadings.indexOf(markedReading.witness) === -1) {
+                                parent.standoff_subreadings.push(markedReading.witness);
+                              }
                             }
                           }
                         }

--- a/static/CE_core/js/subreadings.js
+++ b/static/CE_core/js/subreadings.js
@@ -805,7 +805,6 @@ var SR = (function () {
       reading.witnesses = CL.setList(reading.witnesses);
       delete reading.subreadings;
     }
-
   };
 
 }());

--- a/static/CE_core/js/subreadings.js
+++ b/static/CE_core/js/subreadings.js
@@ -808,6 +808,7 @@ var SR = (function () {
       reading.witnesses = CL.setList(reading.witnesses);
       delete reading.subreadings;
     }
+
   };
 
 }());

--- a/static/js_tests/test_set_variants/test_SV_combineUnits.html
+++ b/static/js_tests/test_set_variants/test_SV_combineUnits.html
@@ -10,6 +10,10 @@
   	<script src="../../../../../common-static/js/jquery-3.7.1.min.js"></script>
 	<script src="../../../../../node_modules/sinon/pkg/sinon.js"></script>
 	<script src="../../../../../node_modules/qunit/qunit/qunit.js"></script>
+    <script src="../../CE_core/js/md5.js"></script>
+    <script src="../../CE_core/js/draggable.js"></script>
+    <script src="../../CE_core/js/redips-drag-5.3.min.js"></script>
+    <script src="../../CE_core/js/spinner.js"></script>
 	<script src="../../CE_core/js/collation.js"></script>
   	<script src="../../CE_core/js/subreadings.js"></script>
     <script src="../../CE_core/js/set_variants.js"></script>
@@ -17,7 +21,18 @@
 
   	<div id="qunit"></div>
  	<div id="qunit-fixture">
-        <div id="scroller"></div>
+        <div id="redips-drag">
+            <div id="header"></div>
+            <div id="scroller">
+                <div id="error-panel">
+                    <div id="error-message-panel"></div>
+                </div>
+            </div>
+            <div id="single-witness-reading"></div>
+            <button id="undo-button"/>
+            
+            
+        </div>
 	</div>
 </body>
 </html>

--- a/static/js_tests/test_set_variants/test_SV_combineUnits.html
+++ b/static/js_tests/test_set_variants/test_SV_combineUnits.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width">
+  <title>SV._combineUnits tests</title>
+  <link rel="stylesheet" href="../../../../../node_modules/qunit/qunit/qunit.css">
+</head>
+<body>
+  	<script src="../../../../../common-static/js/jquery-3.7.1.min.js"></script>
+	<script src="../../../../../node_modules/sinon/pkg/sinon.js"></script>
+	<script src="../../../../../node_modules/qunit/qunit/qunit.js"></script>
+	<script src="../../CE_core/js/collation.js"></script>
+  	<script src="../../CE_core/js/subreadings.js"></script>
+    <script src="../../CE_core/js/set_variants.js"></script>
+	<script src="./test_SV_combineUnits.js"></script>
+
+  	<div id="qunit"></div>
+ 	<div id="qunit-fixture">
+        <div id="scroller"></div>
+	</div>
+</body>
+</html>

--- a/static/js_tests/test_set_variants/test_SV_combineUnits.js
+++ b/static/js_tests/test_set_variants/test_SV_combineUnits.js
@@ -1,0 +1,64 @@
+/* global QUnit, sinon, CL, SV */
+
+QUnit.module('SV _combineUnits', function(hooks) {
+
+    const allRules = {"none": [undefined, false], "reconstructed": ["V", false], "unclear": ["V", false],
+                      "fehler": ["f", true], "fehlerSuff": ["f", false], "orthographic": ["o", true],
+                      "regularised": ["r", false], "abbreviation": ["a", false], "nomsac": ["n", false]};
+
+    hooks.afterEach(function () {
+        sinon.restore();
+    });
+
+    QUnit.test("test _combineUnits 1", (assert) => {
+        /** test two units combining at the same index point where one word in the second is regularised to lac and 
+         * will be combining with an om */
+        sinon.stub(CL, 'getRuleClasses').returns(allRules);
+        
+        const unit1Readings = [
+            {
+                "type": "om", "text": [], "witnesses": ["1", "2"]
+            },
+            {
+                "text": [{"3": {}, "interface": "one", "index": "3.1", "reading": ["3"]}], "witnesses": ["3"]
+            }
+        ];
+        const unit2Readings = [
+            {
+                "type": "om", "text": [], "witnesses": ["1", "3"]
+            },
+            {
+                "type": "lac", "details": "lac", "created": true, "text": [], "witnesses": ["2"], "SR_text": {"2": {}, "interface": "one", "index": "3.1", "reading": ["2"]}
+            }
+        ];
+        const apparatus = [
+            {
+                "start": 3, "end": 3, "first_word_index": "3.1", "_id": "abc123", "readings": unit1Readings
+            },
+            {
+                "start": 3, "end": 3, "first_word_index": "3.2", "_id": "def123", "readings": unit2Readings
+            }
+        ];
+        const markedReadings = {"none":
+            [
+                {
+                    "start": 3,
+                    "end": 3,
+                    "unit_id": "def123",
+                    "first_word_index": "3.2",
+                    "apparatus": "apparatus",
+                    "name": ["None"],
+                    "om_details": "lac",
+                    "parent_text": "&lt;lac&gt;",
+                    "value": "none",
+                    "witness": "2"
+                }
+            ]
+        };
+        CL.data = {"apparatus": apparatus, "marked_readings": markedReadings}
+        SV._combineUnits([0, "apparatus", undefined], [1, "apparatus", undefined])
+        console.log(CL.data)
+
+    });
+
+});

--- a/static/js_tests/test_set_variants/test_SV_combineUnits.js
+++ b/static/js_tests/test_set_variants/test_SV_combineUnits.js
@@ -6,6 +6,15 @@ QUnit.module('SV _combineUnits', function(hooks) {
                       "fehler": ["f", true], "fehlerSuff": ["f", false], "orthographic": ["o", true],
                       "regularised": ["r", false], "abbreviation": ["a", false], "nomsac": ["n", false]};
 
+    hooks.beforeEach(function () {
+
+        CL.project = {};
+        CL.project.prepareDisplayString = function (string) {
+            return string;
+        };
+
+    });
+
     hooks.afterEach(function () {
         sinon.restore();
     });
@@ -14,7 +23,8 @@ QUnit.module('SV _combineUnits', function(hooks) {
         /** test two units combining at the same index point where one word in the second is regularised to lac and 
          * will be combining with an om */
         sinon.stub(CL, 'getRuleClasses').returns(allRules);
-        
+        sinon.stub(CL, 'getCollationHeader').returns([['<div>header row</div>'], 2]);
+
         const unit1Readings = [
             {
                 "type": "om", "text": [], "witnesses": ["1", "2"]
@@ -25,10 +35,21 @@ QUnit.module('SV _combineUnits', function(hooks) {
         ];
         const unit2Readings = [
             {
-                "type": "om", "text": [], "witnesses": ["1", "3"]
+                "type": "om", "text": [], "witnesses": ["1"]
             },
             {
-                "type": "lac", "details": "lac", "created": true, "text": [], "witnesses": ["2"], "SR_text": {"2": {}, "interface": "one", "index": "3.1", "reading": ["2"]}
+                "text": [{"3": {}, "interface": "two", "index": "3.2", "reading": ["3"]}], "witnesses": ["3"]
+            },
+            {
+                "type": "lac", "details": "lac", "created": true, "text": [], "witnesses": ["2"],
+                "SR_text": {
+                    "2": {"text": [{"2": {}, "interface": "[two]", "index": "3.2", "reading": ["2"]}]},
+                }
+            }
+        ];
+        const unit3Readings = [
+            {
+                "text": [{"1": {}, "2": {}, "3": {}, "interface": "three", "index": "4.1", "reading": ["1", "2", "3"]}], "witnesses": ["1", "2", "3"]
             }
         ];
         const apparatus = [
@@ -37,6 +58,9 @@ QUnit.module('SV _combineUnits', function(hooks) {
             },
             {
                 "start": 3, "end": 3, "first_word_index": "3.2", "_id": "def123", "readings": unit2Readings
+            },
+            {
+                "start": 4, "end": 4, "first_word_index": "4.1", "_id": "ghi123", "readings": unit3Readings
             }
         ];
         const markedReadings = {"none":
@@ -51,13 +75,16 @@ QUnit.module('SV _combineUnits', function(hooks) {
                     "om_details": "lac",
                     "parent_text": "&lt;lac&gt;",
                     "value": "none",
-                    "witness": "2"
+                    "witness": "2",
+                    "reading_text": "[two]",
                 }
             ]
         };
-        CL.data = {"apparatus": apparatus, "marked_readings": markedReadings}
-        SV._combineUnits([0, "apparatus", undefined], [1, "apparatus", undefined])
+        CL.data = {"apparatus": apparatus, "marked_readings": markedReadings, "lac_readings": [], "om_readings": []};
+        SV._combineUnits([[0, "apparatus", undefined], [1, "apparatus", undefined]]);
         console.log(CL.data)
+
+        assert.equal(CL.data.apparatus.length, 1);
 
     });
 

--- a/static/js_tests/test_set_variants/test_SV_combineUnits.js
+++ b/static/js_tests/test_set_variants/test_SV_combineUnits.js
@@ -19,73 +19,112 @@ QUnit.module('SV _combineUnits', function(hooks) {
         sinon.restore();
     });
 
+
     QUnit.test("test _combineUnits 1", (assert) => {
-        /** test two units combining at the same index point where one word in the second is regularised to lac and 
-         * will be combining with an om */
+        /** test adjacent two units combining with no regularisations and no empty readings */
         sinon.stub(CL, 'getRuleClasses').returns(allRules);
         sinon.stub(CL, 'getCollationHeader').returns([['<div>header row</div>'], 2]);
 
         const unit1Readings = [
             {
-                "type": "om", "text": [], "witnesses": ["1", "2"]
+                "text": [{"3": {}, "interface": "one", "index": "2.1", "reading": ["3"]}], "witnesses": ["3"]
             },
             {
-                "text": [{"3": {}, "interface": "one", "index": "3.1", "reading": ["3"]}], "witnesses": ["3"]
+                "text": [{"1": {}, "2": {}, "interface": "two", "index": "2.1", "reading": ["1", "2"]}], "witnesses": ["1", "2"]
             }
         ];
         const unit2Readings = [
             {
-                "type": "om", "text": [], "witnesses": ["1"]
-            },
-            {
-                "text": [{"3": {}, "interface": "two", "index": "3.2", "reading": ["3"]}], "witnesses": ["3"]
-            },
-            {
-                "type": "lac", "details": "lac", "created": true, "text": [], "witnesses": ["2"],
-                "SR_text": {
-                    "2": {"text": [{"2": {}, "interface": "[two]", "index": "3.2", "reading": ["2"]}]},
-                }
-            }
-        ];
-        const unit3Readings = [
-            {
                 "text": [{"1": {}, "2": {}, "3": {}, "interface": "three", "index": "4.1", "reading": ["1", "2", "3"]}], "witnesses": ["1", "2", "3"]
             }
         ];
+        
         const apparatus = [
             {
-                "start": 3, "end": 3, "first_word_index": "3.1", "_id": "abc123", "readings": unit1Readings
+                "start": 2, "end": 2, "first_word_index": "3.1", "_id": "abc123", "readings": unit1Readings
             },
             {
-                "start": 3, "end": 3, "first_word_index": "3.2", "_id": "def123", "readings": unit2Readings
-            },
-            {
-                "start": 4, "end": 4, "first_word_index": "4.1", "_id": "ghi123", "readings": unit3Readings
+                "start": 4, "end": 4, "first_word_index": "3.2", "_id": "def123", "readings": unit2Readings
             }
         ];
-        const markedReadings = {"none":
-            [
-                {
-                    "start": 3,
-                    "end": 3,
-                    "unit_id": "def123",
-                    "first_word_index": "3.2",
-                    "apparatus": "apparatus",
-                    "name": ["None"],
-                    "om_details": "lac",
-                    "parent_text": "&lt;lac&gt;",
-                    "value": "none",
-                    "witness": "2",
-                    "reading_text": "[two]",
-                }
-            ]
-        };
-        CL.data = {"apparatus": apparatus, "marked_readings": markedReadings, "lac_readings": [], "om_readings": []};
-        SV._combineUnits([[0, "apparatus", undefined], [1, "apparatus", undefined]]);
-        console.log(CL.data)
 
+        CL.data = {"apparatus": apparatus, "marked_readings": {}, "lac_readings": [], "om_readings": []};
+        SV._combineUnits([[0, "apparatus", undefined], [1, "apparatus", undefined]]);
+        
         assert.equal(CL.data.apparatus.length, 1);
+        
 
     });
+
+
+    // QUnit.test("test _combineUnits 2", (assert) => {
+    //     /** test two units combining at the same index point where one word in the second is regularised to lac and 
+    //      * will be combining with an om */
+    //     console.log('THIS TEST HAS NEVER PASSED')
+    //     sinon.stub(CL, 'getRuleClasses').returns(allRules);
+    //     sinon.stub(CL, 'getCollationHeader').returns([['<div>header row</div>'], 2]);
+
+    //     const unit1Readings = [
+    //         {
+    //             "type": "om", "text": [], "witnesses": ["1", "2"]
+    //         },
+    //         {
+    //             "text": [{"3": {}, "interface": "one", "index": "3.1", "reading": ["3"]}], "witnesses": ["3"]
+    //         }
+    //     ];
+    //     const unit2Readings = [
+    //         {
+    //             "type": "om", "text": [], "witnesses": ["1"]
+    //         },
+    //         {
+    //             "text": [{"3": {}, "interface": "two", "index": "3.2", "reading": ["3"]}], "witnesses": ["3"]
+    //         },
+    //         {
+    //             "type": "lac", "details": "lac", "created": true, "text": [], "witnesses": ["2"],
+    //             "SR_text": {
+    //                 "2": {"text": [{"2": {}, "interface": "[two]", "index": "3.2", "reading": ["2"]}]},
+    //             }
+    //         }
+    //     ];
+    //     const unit3Readings = [
+    //         {
+    //             "text": [{"1": {}, "2": {}, "3": {}, "interface": "three", "index": "4.1", "reading": ["1", "2", "3"]}], "witnesses": ["1", "2", "3"]
+    //         }
+    //     ];
+    //     const apparatus = [
+    //         {
+    //             "start": 3, "end": 3, "first_word_index": "3.1", "_id": "abc123", "readings": unit1Readings
+    //         },
+    //         {
+    //             "start": 3, "end": 3, "first_word_index": "3.2", "_id": "def123", "readings": unit2Readings
+    //         },
+    //         {
+    //             "start": 4, "end": 4, "first_word_index": "4.1", "_id": "ghi123", "readings": unit3Readings
+    //         }
+    //     ];
+    //     const markedReadings = {"none":
+    //         [
+    //             {
+    //                 "start": 3,
+    //                 "end": 3,
+    //                 "unit_id": "def123",
+    //                 "first_word_index": "3.2",
+    //                 "apparatus": "apparatus",
+    //                 "name": ["None"],
+    //                 "om_details": "lac",
+    //                 "parent_text": "&lt;lac&gt;",
+    //                 "value": "none",
+    //                 "witness": "2",
+    //                 "reading_text": "[two]",
+    //             }
+    //         ]
+    //     };
+    //     CL.data = {"apparatus": apparatus, "marked_readings": markedReadings, "lac_readings": [], "om_readings": []};
+    //     SV._combineUnits([[0, "apparatus", undefined], [1, "apparatus", undefined]]);
+    //     console.log(CL.data)
+
+    //     assert.equal(CL.data.apparatus.length, 1);
+
+    // });
 
 });

--- a/static/js_tests/test_set_variants/test_SV_removeOffsetSubreadings.html
+++ b/static/js_tests/test_set_variants/test_SV_removeOffsetSubreadings.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width">
+  <title>SV._combineUnits tests</title>
+  <link rel="stylesheet" href="../../../../../node_modules/qunit/qunit/qunit.css">
+</head>
+<body>
+  	<script src="../../../../../common-static/js/jquery-3.7.1.min.js"></script>
+	<script src="../../../../../node_modules/sinon/pkg/sinon.js"></script>
+	<script src="../../../../../node_modules/qunit/qunit/qunit.js"></script>
+    <script src="../../CE_core/js/md5.js"></script>
+    <script src="../../CE_core/js/draggable.js"></script>
+    <script src="../../CE_core/js/redips-drag-5.3.min.js"></script>
+    <script src="../../CE_core/js/spinner.js"></script>
+	<script src="../../CE_core/js/collation.js"></script>
+  	<script src="../../CE_core/js/subreadings.js"></script>
+    <script src="../../CE_core/js/set_variants.js"></script>
+	<script src="./test_SV_removeOffsetSubreadings.js"></script>
+
+  	<div id="qunit"></div>
+ 	<div id="qunit-fixture">
+        
+	</div>
+</body>
+</html>

--- a/static/js_tests/test_set_variants/test_SV_removeOffsetSubreadings.js
+++ b/static/js_tests/test_set_variants/test_SV_removeOffsetSubreadings.js
@@ -1,0 +1,409 @@
+/* global QUnit, sinon, CL, SV, SR*/
+
+QUnit.module('SV _removeOffsetSubreadings', function (hooks) {
+
+    const allRules = {
+        "none": [undefined, false], "reconstructed": ["V", false], "unclear": ["V", false],
+        "fehler": ["f", true], "fehlerSuff": ["f", false], "orthographic": ["o", true],
+        "regularised": ["r", false], "abbreviation": ["a", false]
+    };
+
+    hooks.beforeEach(function () {
+
+        CL.project = {};
+        CL.project.prepareDisplayString = function (string) {
+            return string;
+        };
+        CL.project.omCategories = [];
+
+    });
+
+    hooks.afterEach(function () {
+        sinon.restore();
+    });
+
+
+    QUnit.test("test _removeOffsetSubreadings 1", (assert) => {
+        /** test a case with no offset subreadings - data should not change */
+        sinon.stub(CL, 'getRuleClasses').returns(allRules);
+
+        CL.data = {
+            "apparatus": [
+                {
+                    "readings": [
+                        {
+                            "witnesses": [
+                                "basetext",
+                                "01",
+                                "33",
+                                "P46",
+                                "L60-S3W2D7",
+                                "6"
+                            ],
+                            "text": [
+                                {
+                                    "6": {
+                                        "_sigil": "6",
+                                        "_token_array_position": 71,
+                                        "decision_class": [
+                                            "abbreviation"
+                                        ],
+                                        "decision_details": [
+                                            {
+                                                "class": "abbreviation",
+                                                "id": 357594,
+                                                "n": "θεου",
+                                                "scope": "once",
+                                                "t": "θυ"
+                                            }
+                                        ],
+                                        "index": "12",
+                                        "n": "θεου",
+                                        "nomSac": true,
+                                        "original": "θυ",
+                                        "rule_match": [
+                                            "θυ"
+                                        ],
+                                        "siglum": "6",
+                                        "t": "θυ"
+                                    },
+                                    "33": {
+                                        "_sigil": "33",
+                                        "_token_array_position": 18,
+                                        "decision_class": [
+                                            "abbreviation"
+                                        ],
+                                        "decision_details": [
+                                            {
+                                                "class": "abbreviation",
+                                                "id": 357591,
+                                                "n": "θεου",
+                                                "scope": "once",
+                                                "t": "θυ"
+                                            }
+                                        ],
+                                        "index": "12",
+                                        "n": "θεου",
+                                        "nomSac": true,
+                                        "original": "θυ",
+                                        "rule_match": [
+                                            "θυ"
+                                        ],
+                                        "siglum": "33",
+                                        "t": "θυ"
+                                    },
+                                    "reading": [
+                                        "basetext",
+                                        "01",
+                                        "33",
+                                        "P46",
+                                        "L60-S3W2D7",
+                                        "6"
+                                    ],
+                                    "verse": "Gal.1.3",
+                                    "interface": "θεου",
+                                    "basetext": {
+                                        "_sigil": "basetext",
+                                        "_token_array_position": 44,
+                                        "index": "12",
+                                        "lemma": "θεου",
+                                        "original": "θεοῦ",
+                                        "rule_match": [
+                                            "θεου"
+                                        ],
+                                        "siglum": "basetext",
+                                        "t": "θεου"
+                                    },
+                                    "index": "12.1",
+                                    "01": {
+                                        "_sigil": "01",
+                                        "_token_array_position": 5,
+                                        "decision_class": [
+                                            "abbreviation"
+                                        ],
+                                        "decision_details": [
+                                            {
+                                                "class": "abbreviation",
+                                                "id": 357590,
+                                                "n": "θεου",
+                                                "scope": "once",
+                                                "t": "θυ"
+                                            }
+                                        ],
+                                        "index": "12",
+                                        "n": "θεου",
+                                        "nomSac": true,
+                                        "original": "θυ",
+                                        "rule_match": [
+                                            "θυ"
+                                        ],
+                                        "siglum": "01",
+                                        "t": "θυ"
+                                    },
+                                    "P46": {
+                                        "_sigil": "P46",
+                                        "_token_array_position": 31,
+                                        "decision_class": [
+                                            "abbreviation"
+                                        ],
+                                        "decision_details": [
+                                            {
+                                                "class": "abbreviation",
+                                                "id": 357592,
+                                                "n": "θεου",
+                                                "scope": "once",
+                                                "t": "θυ"
+                                            }
+                                        ],
+                                        "index": "12",
+                                        "n": "θεου",
+                                        "nomSac": true,
+                                        "original": "θυ",
+                                        "rule_match": [
+                                            "θυ"
+                                        ],
+                                        "siglum": "P46",
+                                        "t": "θυ"
+                                    },
+                                    "L60-S3W2D7": {
+                                        "_sigil": "L60-S3W2D7",
+                                        "_token_array_position": 58,
+                                        "decision_class": [
+                                            "abbreviation"
+                                        ],
+                                        "decision_details": [
+                                            {
+                                                "class": "abbreviation",
+                                                "id": 357593,
+                                                "n": "θεου",
+                                                "scope": "once",
+                                                "t": "θυ"
+                                            }
+                                        ],
+                                        "index": "14",
+                                        "n": "θεου",
+                                        "nomSac": true,
+                                        "original": "θυ",
+                                        "rule_match": [
+                                            "θυ"
+                                        ],
+                                        "siglum": "L60-S3W2D7",
+                                        "t": "θυ"
+                                    }
+                                }
+                            ],
+                            "_id": "cb11e5b44551969c3fc62158cea88581"
+                        }
+                    ],
+                    "start": 12,
+                    "end": 12,
+                    "first_word_index": "12.1",
+                    "_id": "4fac220aa9fcffa6012c45820d761407"
+                }
+            ],
+            "om_readings": [],
+            "lac_readings": [],
+            "special_categories": [],
+            "hand_id_map": {
+                "6": "NT_GRC_6_Gal",
+                "33": "NT_GRC_33_Gal",
+                "01": "NT_GRC_01_Gal",
+                "P46": "NT_GRC_P46_Gal",
+                "basetext": "NT_GRC_basetext_Gal",
+                "L60-S3W2D7": "NT_GRC_L60_Gal"
+            },
+            "marked_readings": {},
+            "separated_witnesses": []
+        }
+
+        const originalData = JSON.stringify(CL.data);
+        // prepare the expected result
+        CL.data = JSON.parse(originalData);
+        SR.loseSubreadings();
+        SR.findSubreadings();
+        const expectedData = JSON.stringify(CL.data);
+        // put the original back to run the test
+        CL.data = JSON.parse(originalData);
+        SV._removeOffsetSubreadings();
+        assert.equal(expectedData, JSON.stringify(CL.data));
+    });
+
+    QUnit.test("test _removeOffsetSubreadings 2", (assert) => {
+        /** test a case with no offset subreadings - data should not change */
+        sinon.stub(CL, 'getRuleClasses').returns(allRules);
+
+        CL.data = {
+            "apparatus": [
+                {
+                    "readings": [
+                        {
+                            "witnesses": [
+                                "01",
+                                "33",
+                                "basetext"
+                            ],
+                            "text": [
+                                {
+                                    "33": {
+                                        "_sigil": "33",
+                                        "_token_array_position": 20,
+                                        "index": "16",
+                                        "original": "ημων",
+                                        "rule_match": [
+                                            "ημων"
+                                        ],
+                                        "siglum": "33",
+                                        "t": "ημων"
+                                    },
+                                    "reading": [
+                                        "01",
+                                        "33",
+                                        "basetext"
+                                    ],
+                                    "verse": "Gal.1.3",
+                                    "interface": "ημων",
+                                    "01": {
+                                        "_sigil": "01",
+                                        "_token_array_position": 7,
+                                        "index": "16",
+                                        "original": "ημων",
+                                        "rule_match": [
+                                            "ημων"
+                                        ],
+                                        "siglum": "01",
+                                        "t": "ημων"
+                                    },
+                                    "basetext": {
+                                        "_sigil": "basetext",
+                                        "_token_array_position": 46,
+                                        "index": "16",
+                                        "lemma": "ημων",
+                                        "original": "ἡμῶν",
+                                        "rule_match": [
+                                            "ημων"
+                                        ],
+                                        "siglum": "basetext",
+                                        "t": "ημων"
+                                    },
+                                    "index": "16.1"
+                                }
+                            ],
+                            "_id": "1e3f145bc4c0a117b4af276ff5501cf4"
+                        },
+                        {
+                            "_id": "1c4e939e8ffc52c632a389359de82b37",
+                            "created": true,
+                            "text": [
+                                {
+                                    "index": "0",
+                                    "interface": "test",
+                                    "reading": []
+                                }
+                            ],
+                            "witnesses": [
+                                "P46"
+                            ],
+                            "SR_text": {
+                                "P46": {
+                                    "text": [],
+                                    "type": "om"
+                                }
+                            }
+                        },
+                        {
+                            "witnesses": [
+                                "L60-S3W2D7",
+                                "6"
+                            ],
+                            "text": [],
+                            "type": "om",
+                            "_id": "6d35e2bd6d2c5f7d21f048bc40ffff19"
+                        }
+                    ],
+                    "start": 16,
+                    "end": 16,
+                    "first_word_index": "16.1",
+                    "_id": "53c957b31ea2139d2205ec42756e815c"
+                }
+            ],
+            "om_readings": [],
+            "lac_readings": [],
+            "special_categories": [],
+            "hand_id_map": {
+                "6": "NT_GRC_6_Gal",
+                "33": "NT_GRC_33_Gal",
+                "01": "NT_GRC_01_Gal",
+                "P46": "NT_GRC_P46_Gal",
+                "basetext": "NT_GRC_basetext_Gal",
+                "L60-S3W2D7": "NT_GRC_L60_Gal"
+            },
+            "marked_readings": {
+                "reconstructed": [
+                    {
+                        "start": 16,
+                        "end": 16,
+                        "unit_id": "53c957b31ea2139d2205ec42756e815c",
+                        "first_word_index": "16.1",
+                        "witness": "P46",
+                        "apparatus": "apparatus",
+                        "reading_text": "om.",
+                        "parent_text": "test",
+                        "identifier": [
+                            "V"
+                        ],
+                        "suffixed_sigla": [
+                            true
+                        ],
+                        "suffixed_label": [
+                            false
+                        ],
+                        "reading_history": [
+                            "om."
+                        ],
+                        "value": "reconstructed",
+                        "subreading": [
+                            false
+                        ],
+                        "name": [
+                            "Reconstructed"
+                        ],
+                        "type": "om"
+                    }
+                ]
+            },
+            "separated_witnesses": []
+        };
+        const originalData = JSON.stringify(CL.data);
+        let expectedData = JSON.parse(originalData);
+        const expectedChangedReading = {
+            "witnesses": [
+                "P46"
+            ],
+            "text": [],
+            "type": "om",
+            "_id": ""
+        }
+        expectedData.apparatus[0].readings[1] = expectedChangedReading;
+        expectedData = JSON.stringify(expectedData);
+
+        // put the original back to run the test
+        CL.data = JSON.parse(originalData);
+        SV._removeOffsetSubreadings();
+        SR.loseSubreadings();
+        // remove the _id value because it will be unpredictable
+        CL.data.apparatus[0].readings[1]._id = "";
+        assert.equal(expectedData, JSON.stringify(CL.data));
+
+        // now check if we can find the subreadings again and lose them (always have to lose them first)
+        // and end up back where we started
+        SR.loseSubreadings();
+        SR.findSubreadings();
+        SR.loseSubreadings();
+        let newExpectedData = JSON.parse(originalData);
+        newExpectedData.apparatus[0].readings[1]._id = "";
+        newExpectedData = JSON.stringify(newExpectedData);
+        CL.data.apparatus[0].readings[1]._id = "";
+        assert.equal(newExpectedData, JSON.stringify(CL.data));
+    });
+
+});


### PR DESCRIPTION
This fixes what I hope is the final problem when removing overlaps.

The problem was caused by a check for first_word_index being missing in one place when finding and removing subreadings. It meant that I was getting inconsistent behaviour when a very unusual set of cirumstances came together. I have fixed that problem by adding an extra check in subreadings.js which I think is the only change in that file, it just looks huge because everything in the function has been indented by one level.

Fixing that problem meant that the word numbering of units in odd numbered word indexes needed to be very accurate. This lead to a change in the way we handle remove overlapping units. Previously I was allowing the removal process to add units in the odd numbered word 'gaps' on either side of the unit being removed (which happened quite regularly due to overlaps often being used to handle changes in word order). I realised that doing so meant that renumbering units and words appropriately was too complex so now I join any addition units into the first or final unit of the range of text covered by the overlap being removed. Basically keeping the text within the boundaries of the original overlap unit that is being removed. The editors can then fix the result and all of the normal processes of the editor can handle that perfectly fine.

I also did some testing experiments as part of this which didn't end up being useful for debugging but could be a starting point for our 'big topic' meeting on testing and test data.

**Update**

I have changed the function in set variants so that if the redraw arg is undefined it is set to false. This removed the need to say !== false in line 2564 and we can rely on just saying ===true