### PR TITLE
fix for duplicated reading suffixes in export

### DIFF
--- a/docs/upgrade-notes/upgrade-1cor-dev.md
+++ b/docs/upgrade-notes/upgrade-1cor-dev.md
@@ -18,9 +18,14 @@ ids or class names in your own css to change the look or behaviour of the collat
 
 + There has been a change to the way the `SV_moveReading()` function reindexes the reading being moved which aims to improve
 the user experience when large chunks of text have to be moved to correct the initial collation.
++ There is a bug fix in the approval stage which prevents reading suffixes being duplicated in the data. This has also been
+fixed in the restreucture_export_data_mixin to deal with any data already approved. It is fixed here in the JavaScript for users
+who do not use the provided exporter.
 
 ## Python
 
 + The exporter has a new function `get_subreadings` which gives the option to overwrite this in inheriting classes should
 that be necessary (we use it for the apparatus editor which restructures subreadings into a list), should not require
 any changes to existing code (just here for info).
++ There is a bug fix in the restructure_export_data_mixin which will always recreate the reading suffix due to the bug
+that was present in the Javascript approval stage.

--- a/docs/upgrade-notes/upgrade-1cor-dev.md
+++ b/docs/upgrade-notes/upgrade-1cor-dev.md
@@ -19,7 +19,7 @@ ids or class names in your own css to change the look or behaviour of the collat
 + There has been a change to the way the `SV_moveReading()` function reindexes the reading being moved which aims to improve
 the user experience when large chunks of text have to be moved to correct the initial collation.
 + There is a bug fix in the approval stage which prevents reading suffixes being duplicated in the data. This has also been
-fixed in the restreucture_export_data_mixin to deal with any data already approved. It is fixed here in the JavaScript for users
+fixed in the restructure_export_data_mixin to deal with any data already approved. It is fixed here in the JavaScript for users
 who do not use the provided exporter.
 
 ## Python

--- a/restructure_export_data_mixin.py
+++ b/restructure_export_data_mixin.py
@@ -106,15 +106,16 @@ class RestructureExportDataMixin(object):
                 if len(label_suffixes) > 0:
                     label_suffixes.sort()
                 reading['label_suffix'] = ''.join(label_suffixes)
-            if 'reading_suffix' not in reading:
-                reading_suffixes = []
-                for clss in reading['reading_classes']:
-                    for rule in self.rule_classes:
-                        if rule['value'] == clss:
-                            if rule['suffixed_reading'] is True:
-                                reading_suffixes.append(rule['identifier'])
-                if len(reading_suffixes) > 0:
-                    reading['reading_suffix'] = ''.join(reading_suffixes)
+            # the reading_suffix needs fixing regardless because there was a bug in the collation editor which was
+            # duplicating the labels at the approve stage.
+            reading_suffixes = []
+            for clss in reading['reading_classes']:
+                for rule in self.rule_classes:
+                    if rule['value'] == clss:
+                        if rule['suffixed_reading'] is True:
+                            reading_suffixes.append(rule['identifier'])
+            if len(reading_suffixes) > 0:
+                reading['reading_suffix'] = ''.join(reading_suffixes)
 
     def _simplify_text_list(self, reading):
         """Simplify the list of tokens provided in the text key so it only includes the interface string.

--- a/static/CE_core/js/order_readings.js
+++ b/static/CE_core/js/order_readings.js
@@ -953,8 +953,6 @@ var OR = (function() {
             OR._numberEditionSubreadings();
           }
           OR._getSiglaSuffixes();
-          // TODO: fosilise the reading suffixes and main reading label suffixes here
-          // then make output dependent on these not being present
           OR._getMainReadingSpecialClasses();
           // The following comment is no longer true as we do have that button in the approved screen!
           // at this point the saved approved version always and only ever has the correct subreadings shown we
@@ -988,34 +986,36 @@ var OR = (function() {
     },
 
     _getMainReadingSpecialClasses: function () {
-      let unit, reading;
-      const ruleClasses = CL.getRuleClasses('keep_as_main_reading', true, 'value', ['identifier', 'suffixed_label',
-                                                                                    'suffixed_reading']);
+      const ruleClasses = CL.getRuleClasses(
+        'keep_as_main_reading', true, 'value', ['identifier', 'suffixed_label', 'suffixed_reading']
+      );
       if ($.isEmptyObject(ruleClasses)) {
           return;
       }
       for (const key in CL.data) {
         if (Object.prototype.hasOwnProperty.call(CL.data, key)) {
           if (key.indexOf('apparatus') != -1) {
-            for (let i = 0; i < CL.data[key].length; i += 1) {
-              unit = CL.data[key][i];
-              for (let j = 0; j < unit.readings.length; j += 1) {
-                reading = unit.readings[j];
+            for (let unit of CL.data[key]) {
+              for (let reading of unit.readings) {
                 if (Object.prototype.hasOwnProperty.call(reading, 'reading_classes') && reading.reading_classes.length > 0) {
-                  for (let k = 0; k < reading.reading_classes.length; k += 1) {
-                    if (Object.prototype.hasOwnProperty.call(ruleClasses, reading.reading_classes[k])) {
-                      if (ruleClasses[reading.reading_classes[k]][1] === true) {
+                  for (let readingClass of reading.reading_classes) {
+                    if (Object.prototype.hasOwnProperty.call(ruleClasses, readingClass)) {
+                      if (ruleClasses[readingClass][1] === true) {
                         if (Object.prototype.hasOwnProperty.call(reading, 'label_suffix')) {
-                          reading.label_suffix = reading.label_suffix + ruleClasses[reading.reading_classes[k]][0];
+                          if (reading.label_suffix.indexOf(ruleClasses[readingClass][0]) === -1) {
+                            reading.label_suffix = reading.label_suffix + ruleClasses[readingClass][0];
+                          }
                         } else {
-                          reading.label_suffix = ruleClasses[reading.reading_classes[k]][0];
+                          reading.label_suffix = ruleClasses[readingClass][0];
                         }
                       }
-                      if (ruleClasses[reading.reading_classes[k]][2] === true) {
+                      if (ruleClasses[readingClass][2] === true) {
                         if (Object.prototype.hasOwnProperty.call(reading, 'reading_suffix')) {
-                          reading.reading_suffix = reading.reading_suffix + ruleClasses[reading.reading_classes[k]][0];
+                          if (reading.reading_suffix.indexOf(ruleClasses[readingClass][0])) {
+                            reading.reading_suffix = reading.reading_suffix + ruleClasses[readingClass][0];
+                          }
                         } else {
-                          reading.reading_suffix = ruleClasses[reading.reading_classes[k]][0];
+                          reading.reading_suffix = ruleClasses[readingClass][0];
                         }
                       }
                     }


### PR DESCRIPTION
This fixes the same bug in two places.

The Javascript was duplicating the reading suffixes when a verse was approved. This was then being used unchanged in the Python exports.

I have fixed it in both places so new data will be accurate but legacy data will also not have the duplication in the exports because it will be regenerated. It is worth fixing it in both places because not all users of this software will be using the Python export I provide.

While fixing the JavaScript function I also updating the loops to use the 'of' version rather than the index numbers and removed a comment that was no longer true as the following function does that thing.

It also adds a note on the bug fix to the docs which record all the changes.

