### PR TITLE
allow optional kwargs in exporter factory

### DIFF
--- a/exporter_factory.py
+++ b/exporter_factory.py
@@ -23,13 +23,14 @@ class ExporterFactory(object):
         MyClass = getattr(importlib.import_module(module_name), class_name)
         self.exporter = MyClass(**options)
 
-    def export_data(self, data):
+    def export_data(self, data, **kwargs):
         """Start the export by calling the exporter function from the exporter class specified.
 
         Args:
             data (list): A list of JSON objects each representing a collation unit of the data to be exported.
+            **kwargs: The optional keyword arguments for the exporter being called.
 
         Returns:
             unknown: The return value of the function called.
         """
-        return getattr(self.exporter, self.exporter_function)(data)
+        return getattr(self.exporter, self.exporter_function)(data, **kwargs)


### PR DESCRIPTION
This adds optional kwargs when calling export data via the exporter factory.

This is so we can pass in the target chapter number so that the merge units mixin can then handle the cross chapter joins.